### PR TITLE
Feat: Implemented Listing Favorite System

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { ListingsModule } from './listing/listing.module';
 import { MarketPlaceModule } from './market-place/market-place.module';
 import { WalletModule } from './wallet/wallet.module';
 import { UserModule } from './user/user.module';
+import { FavoritesModule } from './favorites/favorites.module'; // Add this import
+
 
 @Module({
   imports: [
@@ -37,6 +39,8 @@ import { UserModule } from './user/user.module';
     WalletModule,
 
     UserModule,
+
+    FavoritesModule
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/favorites/favorites.controller.spec.ts
+++ b/src/favorites/favorites.controller.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FavoritesController } from './favorites.controller';
+import { FavoritesService } from './favorites.service';
+
+describe('FavoritesController', () => {
+  let controller: FavoritesController;
+  let favoritesService: FavoritesService;
+
+  const mockRequest = {
+    user: { id: 1 },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FavoritesController],
+      providers: [
+        {
+          provide: FavoritesService,
+          useValue: {
+            favoriteListing: jest.fn(),
+            unfavoriteListing: jest.fn(),
+            getUserFavorites: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<FavoritesController>(FavoritesController);
+    favoritesService = module.get<FavoritesService>(FavoritesService);
+  });
+
+  describe('favoriteListing', () => {
+    it('should favorite a listing successfully', async () => {
+      jest.spyOn(favoritesService, 'favoriteListing').mockResolvedValue();
+
+      const result = await controller.favoriteListing('1', mockRequest);
+
+      expect(favoritesService.favoriteListing).toHaveBeenCalledWith(1, 1);
+      expect(result).toEqual({ message: 'Listing added to favorites successfully' });
+    });
+  });
+
+  describe('unfavoriteListing', () => {
+    it('should unfavorite a listing successfully', async () => {
+      jest.spyOn(favoritesService, 'unfavoriteListing').mockResolvedValue();
+
+      const result = await controller.unfavoriteListing('1', mockRequest);
+
+      expect(favoritesService.unfavoriteListing).toHaveBeenCalledWith(1, 1);
+      expect(result).toEqual({ message: 'Listing removed from favorites successfully' });
+    });
+  });
+
+  describe('getUserFavorites', () => {
+    it('should return user favorites', async () => {
+      const mockFavorites = [{ id: 1, title: 'Test Listing' }];
+      jest.spyOn(favoritesService, 'getUserFavorites').mockResolvedValue(mockFavorites as any);
+
+      const result = await controller.getUserFavorites(mockRequest);
+
+      expect(favoritesService.getUserFavorites).toHaveBeenCalledWith(1);
+      expect(result).toEqual({ favorites: mockFavorites });
+    });
+  });
+});

--- a/src/favorites/favorites.controller.ts
+++ b/src/favorites/favorites.controller.ts
@@ -1,0 +1,48 @@
+import { 
+  Controller, 
+  Post, 
+  Delete, 
+  Param, 
+  UseGuards, 
+  Request,
+  HttpCode,
+  HttpStatus,
+  Get
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { FavoritesService } from './favorites.service';
+
+@Controller('listings')
+@UseGuards(AuthGuard('jwt')) 
+export class FavoritesController {
+  constructor(private readonly favoritesService: FavoritesService) {}
+
+  @Post(':id/favorite')
+  @HttpCode(HttpStatus.CREATED)
+  async favoriteListing(
+    @Param('id') listingId: string,
+    @Request() req: any,
+  ): Promise<{ message: string }> {
+    const userId = req.user.id;
+    await this.favoritesService.favoriteListing(userId, parseInt(listingId));
+    return { message: 'Listing added to favorites successfully' };
+  }
+
+  @Delete(':id/favorite')
+  @HttpCode(HttpStatus.OK)
+  async unfavoriteListing(
+    @Param('id') listingId: string,
+    @Request() req: any,
+  ): Promise<{ message: string }> {
+    const userId = req.user.id;
+    await this.favoritesService.unfavoriteListing(userId, parseInt(listingId));
+    return { message: 'Listing removed from favorites successfully' };
+  }
+
+  @Get('favorites')
+  async getUserFavorites(@Request() req: any) {
+    const userId = req.user.id;
+    const favorites = await this.favoritesService.getUserFavorites(userId);
+    return { favorites };
+  }
+}

--- a/src/favorites/favorites.module.ts
+++ b/src/favorites/favorites.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FavoritesController } from './favorites.controller';
+import { FavoritesService } from './favorites.service';
+import { User } from '../users/user.entity';
+import { Listing } from '../listings/listing.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Listing])],
+  controllers: [FavoritesController],
+  providers: [FavoritesService],
+  exports: [FavoritesService],
+})
+export class FavoritesModule {}

--- a/src/favorites/favorites.service.spec.ts
+++ b/src/favorites/favorites.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FavoritesService } from './favorites.service';
+import { User } from '../users/user.entity';
+import { Listing } from '../listings/listing.entity';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+
+describe('FavoritesService', () => {
+  let service: FavoritesService;
+  let userRepository: Repository<User>;
+  let listingRepository: Repository<Listing>;
+
+  const mockUser = {
+    id: 1,
+    email: 'test@example.com',
+    favoriteListings: [],
+  };
+
+  const mockListing = {
+    id: 1,
+    title: 'Test Listing',
+    description: 'Test Description',
+    price: 100,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FavoritesService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Listing),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FavoritesService>(FavoritesService);
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+    listingRepository = module.get<Repository<Listing>>(getRepositoryToken(Listing));
+  });
+
+  describe('favoriteListing', () => {
+    it('should successfully favorite a listing', async () => {
+      const userWithFavorites = { ...mockUser, favoriteListings: [] };
+      
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(userWithFavorites);
+      jest.spyOn(listingRepository, 'findOne').mockResolvedValue(mockListing as Listing);
+      jest.spyOn(userRepository, 'save').mockResolvedValue(userWithFavorites as unknown as User);
+
+      await service.favoriteListing(1, 1);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['favoriteListings'],
+      });
+      expect(listingRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+      expect(userRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when user not found', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.favoriteListing(1, 1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when listing not found', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser as unknown as User);
+      jest.spyOn(listingRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.favoriteListing(1, 1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException when listing already favorited', async () => {
+      const userWithFavorites = { 
+        ...mockUser, 
+        favoriteListings: [mockListing as Listing] 
+      };
+      
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(userWithFavorites as User);
+      jest.spyOn(listingRepository, 'findOne').mockResolvedValue(mockListing as Listing);
+
+      await expect(service.favoriteListing(1, 1)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('unfavoriteListing', () => {
+    it('should successfully unfavorite a listing', async () => {
+      const userWithFavorites = { 
+        ...mockUser, 
+        favoriteListings: [mockListing as Listing] 
+      };
+      
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(userWithFavorites as User);
+      jest.spyOn(userRepository, 'save').mockResolvedValue(userWithFavorites as User);
+
+      await service.unfavoriteListing(1, 1);
+
+      expect(userRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when user not found', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(service.unfavoriteListing(1, 1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when listing not in favorites', async () => {
+      const userWithFavorites = { ...mockUser, favoriteListings: [] };
+      
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(userWithFavorites as unknown as User);
+
+      await expect(service.unfavoriteListing(1, 1)).rejects.toThrow(NotFoundException);
+    });
+  });
+});
+

--- a/src/favorites/favorites.service.ts
+++ b/src/favorites/favorites.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Listing } from '../listings/listing.entity';
+
+@Injectable()
+export class FavoritesService {
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    @InjectRepository(Listing)
+    private listingRepository: Repository<Listing>,
+  ) {}
+
+  async favoriteListing(userId: number, listingId: number): Promise<void> {
+    // Find user with their favorite listings
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: ['favoriteListings'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Find the listing
+    const listing = await this.listingRepository.findOne({
+      where: { id: listingId },
+    });
+
+    if (!listing) {
+      throw new NotFoundException('Listing not found');
+    }
+
+    // Check if listing is already favorited
+    const isAlreadyFavorited = user.favoriteListings.some(
+      (favListing) => favListing.id === listingId,
+    );
+
+    if (isAlreadyFavorited) {
+      throw new ConflictException('Listing is already favorited');
+    }
+
+    // Add listing to favorites
+    user.favoriteListings.push(listing);
+    await this.userRepository.save(user);
+  }
+
+  async unfavoriteListing(userId: number, listingId: number): Promise<void> {
+    // Find user with their favorite listings
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: ['favoriteListings'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Check if listing is in favorites
+    const favoriteIndex = user.favoriteListings.findIndex(
+      (listing) => listing.id === listingId,
+    );
+
+    if (favoriteIndex === -1) {
+      throw new NotFoundException('Listing not found in favorites');
+    }
+
+    // Remove listing from favorites
+    user.favoriteListings.splice(favoriteIndex, 1);
+    await this.userRepository.save(user);
+  }
+
+  async getUserFavorites(userId: number): Promise<Listing[]> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: ['favoriteListings'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    return user.favoriteListings;
+  }
+
+  async isListingFavorited(userId: number, listingId: number): Promise<boolean> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: ['favoriteListings'],
+    });
+
+    if (!user) {
+      return false;
+    }
+
+    return user.favoriteListings.some((listing) => listing.id === listingId);
+  }
+}

--- a/src/listings/listing.entity.ts
+++ b/src/listings/listing.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, ManyToMany } from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity('listings')
+export class Listing {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column('text')
+  description: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  price: number;
+
+  @Column()
+  category: string;
+
+  @Column()
+  location: string;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+
+  @ManyToOne(() => User)
+  owner: User;
+
+  @ManyToMany(() => User, (user) => user.favoriteListings)
+  favoritedBy: User[];
+}

--- a/src/migrations/[timestamp]-create-user-favorites-table.ts
+++ b/src/migrations/[timestamp]-create-user-favorites-table.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table, Index } from 'typeorm';
+
+export class CreateUserFavoritesTable1678901234567 implements MigrationInterface {
+  name = 'CreateUserFavoritesTable1678901234567';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_favorites',
+        columns: [
+          {
+            name: 'user_id',
+            type: 'int',
+            isPrimary: true,
+          },
+          {
+            name: 'listing_id',
+            type: 'int',
+            isPrimary: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['user_id'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['listing_id'],
+            referencedTableName: 'listings',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Create indexes for better performance
+    await queryRunner.createIndex(
+      'user_favorites',
+      new Index('IDX_USER_FAVORITES_USER_ID', ['user_id']),
+    );
+
+    await queryRunner.createIndex(
+      'user_favorites',
+      new Index('IDX_USER_FAVORITES_LISTING_ID', ['listing_id']),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user_favorites');
+  }
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,6 +1,7 @@
-// src/users/user.entity.ts
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
 import { Exclude } from 'class-transformer';
+import { Listing } from '../listings/listing.entity';
+
 
 @Entity('users')
 export class User {
@@ -28,4 +29,18 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+    @ManyToMany(() => Listing, (listing) => listing.favoritedBy)
+  @JoinTable({
+    name: 'user_favorites',
+    joinColumn: {
+      name: 'user_id',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'listing_id',
+      referencedColumnName: 'id',
+    },
+  })
+  favoriteListings: Listing[];
 }


### PR DESCRIPTION
### Issue Reference:  
Closes #17 


## Description:  
This PR introduces functionality for users to favorite and unfavorite listings, enabling efficient bookmarking of items of interest.  

## Changes Implemented:  
- Added **POST /listings/:id/favorite** endpoint to allow users to favorite a listing  
- Added **DELETE /listings/:id/favorite** endpoint to remove a listing from favorites  
- Established a **many-to-many relationship** between User and Listing entities using a join table  
- Implemented **auth guard enforcement** to ensure authentication on both endpoints  
- Updated **favorites service** in `src/favorites/favorites.service.ts`  
- Added **comprehensive tests** to verify favoriting and unfavoriting functionality  

## How to Test:  
```
Npm Run Test
1. Authenticate a user and send a POST request to `/listings/:id/favorite`  
2. Verify that the listing appears in the user's favorites  
3. Send a DELETE request to `/listings/:id/favorite` and confirm removal  
4. Ensure auth guard prevents unauthorized access  
5. Run tests to validate favoriting/unfavoriting logic  

```
## Checklist 
- Favoriting and unfavoriting work correctly  
- Auth guard is properly enforced  
- Changes reflect in impacted files  
- No breaking changes introduced  


