### PR TITLE
Implement soft delete

### DIFF
--- a/src/deleted-listings/deleted-listings.controller.ts
+++ b/src/deleted-listings/deleted-listings.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Post, Param, Query, ParseUUIDPipe } from '@nestjs/common';
+import { DeletedListingsService } from './deleted-listings.service';
+
+@Controller('deleted-listings')
+export class DeletedListingsController {
+  constructor(private readonly deletedListingsService: DeletedListingsService) {}
+
+  @Get()
+  findAllDeleted(
+    @Query('take') take?: string,
+    @Query('skip') skip?: string,
+  ) {
+    const parsedTake = take ? parseInt(take, 10) : 10;
+    const parsedSkip = skip ? parseInt(skip, 10) : 0;
+    return this.deletedListingsService.findAllDeleted(parsedTake, parsedSkip);
+  }
+
+  @Get(':id')
+  findOneDeleted(@Param('id', ParseUUIDPipe) id: string) {
+    return this.deletedListingsService.findOneDeleted(id);
+  }
+
+  @Post(':id/restore')
+  restore(@Param('id', ParseUUIDPipe) id: string) {
+    return this.deletedListingsService.restore(id);
+  }
+} 

--- a/src/deleted-listings/deleted-listings.module.ts
+++ b/src/deleted-listings/deleted-listings.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DeletedListingsController } from './deleted-listings.controller';
+import { DeletedListingsService } from './deleted-listings.service';
+import { Listing } from '../listing/entities/listing.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Listing])],
+  controllers: [DeletedListingsController],
+  providers: [DeletedListingsService],
+  exports: [DeletedListingsService],
+})
+export class DeletedListingsModule {} 

--- a/src/deleted-listings/deleted-listings.service.ts
+++ b/src/deleted-listings/deleted-listings.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Not, IsNull } from 'typeorm';
+import { Listing } from '../listing/entities/listing.entity';
+
+@Injectable()
+export class DeletedListingsService {
+  constructor(
+    @InjectRepository(Listing)
+    private readonly listingRepository: Repository<Listing>,
+  ) {}
+
+  async findAllDeleted(take = 10, skip = 0): Promise<{ listings: Listing[]; total: number }> {
+    const [listings, total] = await this.listingRepository.findAndCount({
+      withDeleted: true,
+      where: {
+        deletedAt: Not(IsNull()),
+      },
+      order: { deletedAt: 'DESC' },
+      take,
+      skip,
+    });
+
+    return { listings, total };
+  }
+
+  async findOneDeleted(id: string): Promise<Listing> {
+    const listing = await this.listingRepository.findOne({
+      where: { id },
+      withDeleted: true,
+    });
+
+    if (!listing || !listing.deletedAt) {
+      throw new NotFoundException(`Deleted listing with ID ${id} not found`);
+    }
+
+    return listing;
+  }
+
+  async restore(id: string): Promise<Listing> {
+    const listing = await this.findOneDeleted(id);
+    await this.listingRepository.restore(id);
+    return this.listingRepository.findOneBy({ id });
+  }
+} 


### PR DESCRIPTION
# Soft Deletion Implementation for Listings

## Overview
This PR implements soft deletion functionality for listings, allowing them to be "deleted" while preserving the data for potential restoration later. The implementation follows NestJS best practices and utilizes TypeORM's built-in soft deletion mechanisms.

## Changes Made

### 1. Listing Entity Updates
- Added `@DeleteDateColumn()` to `Listing` entity to track soft deletion timestamps
- The `deletedAt` column will automatically be populated when a listing is soft-deleted

### 2. New DeletedListings Resource
Created a new resource module for managing soft-deleted listings:

#### Module Structure
- `DeletedListingsModule`: Main module configuration
- `DeletedListingsController`: Handles HTTP requests for deleted listings
- `DeletedListingsService`: Business logic for managing deleted listings

#### New Endpoints
- `GET /deleted-listings`: List all soft-deleted listings (with pagination)
- `GET /deleted-listings/:id`: Get details of a specific soft-deleted listing
- `POST /deleted-listings/:id/restore`: Restore a soft-deleted listing

### 3. Listing Service Updates
- Modified the `delete` method to use `softDelete()` instead of `remove()`
- Soft-deleted listings are automatically filtered out from regular queries
- Added proper error handling for deleted listings

### 4. App Module Updates
- Added `DeletedListingsModule` to the application's imports

## Technical Details

### Soft Deletion Implementation
- Uses TypeORM's `@DeleteDateColumn` decorator
- Automatically sets the `deletedAt` timestamp when a listing is soft-deleted
- Regular queries automatically exclude soft-deleted records
- Uses `withDeleted: true` option to include soft-deleted records when needed

### Pagination Support
- Both listing and deleted listing endpoints support pagination
- Default page size: 10 items
- Supports `take` and `skip` query parameters

## Testing
The following scenarios should be tested:
1. Regular deletion of a listing (should now be soft-deleted)
2. Verifying soft-deleted listings don't appear in regular queries
3. Viewing soft-deleted listings through the new endpoints
4. Restoring a soft-deleted listing
5. Verifying restored listings reappear in regular queries

## Dependencies
The following dependencies are required:
- @nestjs/common
- @nestjs/typeorm
- typeorm
- @nestjs/config

## Migration Notes
No database migration is required as the `deletedAt` column will be automatically added by TypeORM's synchronize feature. However, in production, a proper migration should be created.

## Security Considerations
- All endpoints should be properly secured with authentication
- Consider adding authorization checks to ensure only authorized users can restore listings 