### PR TITLE
feat: implement transaction history endpoint

### DIFF
--- a/src/transactions/dto/transaction-response.dto.ts
+++ b/src/transactions/dto/transaction-response.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TransactionStatus, TransactionType } from '../entities/transaction.entity';
+
+export class UserDto {
+  @ApiProperty({ description: 'User ID' })
+  id: number;
+
+  @ApiProperty({ description: 'User email' })
+  email: string;
+
+  @ApiProperty({ description: 'User name' })
+  name: string;
+}
+
+export class TransactionResponseDto {
+  @ApiProperty({ description: 'Transaction ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Transaction amount' })
+  amount: number;
+
+  @ApiProperty({ description: 'Transaction currency' })
+  currency: string;
+
+  @ApiProperty({ description: 'Transaction description', required: false })
+  description?: string;
+
+  @ApiProperty({ description: 'Transaction status', enum: TransactionStatus })
+  status: TransactionStatus;
+
+  @ApiProperty({ description: 'Transaction type', enum: TransactionType })
+  type: TransactionType;
+
+  @ApiProperty({ description: 'Sender information', type: UserDto })
+  sender: UserDto;
+
+  @ApiProperty({ description: 'Receiver information', type: UserDto })
+  receiver: UserDto;
+
+  @ApiProperty({ description: 'Transaction creation date' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Transaction last update date' })
+  updatedAt: Date;
+} 

--- a/src/transactions/entities/transaction.entity.ts
+++ b/src/transactions/entities/transaction.entity.ts
@@ -1,0 +1,96 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '../../users/user.entity';
+
+export enum TransactionStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  CANCELLED = 'cancelled',
+}
+
+export enum TransactionType {
+  TRANSFER = 'transfer',
+  PAYMENT = 'payment',
+  REFUND = 'refund',
+  PURCHASE = 'purchase',
+}
+
+@Entity('transactions')
+@Index(['senderId', 'createdAt'])
+@Index(['receiverId', 'createdAt'])
+@Index(['status', 'createdAt'])
+export class Transaction {
+  @ApiProperty({ description: 'Unique transaction identifier' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Transaction amount' })
+  @Column('decimal', { precision: 10, scale: 2 })
+  amount: number;
+
+  @ApiProperty({ description: 'Transaction currency', default: 'USD' })
+  @Column({ length: 3, default: 'USD' })
+  currency: string;
+
+  @ApiProperty({ description: 'Transaction description' })
+  @Column('text', { nullable: true })
+  description: string;
+
+  @ApiProperty({ description: 'Transaction status', enum: TransactionStatus })
+  @Column({
+    type: 'enum',
+    enum: TransactionStatus,
+    default: TransactionStatus.PENDING,
+  })
+  status: TransactionStatus;
+
+  @ApiProperty({ description: 'Transaction type', enum: TransactionType })
+  @Column({
+    type: 'enum',
+    enum: TransactionType,
+    default: TransactionType.TRANSFER,
+  })
+  type: TransactionType;
+
+  @ApiProperty({ description: 'Sender user ID' })
+  @Column({ name: 'sender_id' })
+  @Index()
+  senderId: number;
+
+  @ApiProperty({ description: 'Receiver user ID' })
+  @Column({ name: 'receiver_id' })
+  @Index()
+  receiverId: number;
+
+  @ApiProperty({ description: 'Related listing ID if transaction is for a purchase' })
+  @Column({ name: 'listing_id', nullable: true })
+  listingId: string;
+
+  @ApiProperty({ description: 'Transaction metadata' })
+  @Column('json', { nullable: true })
+  metadata: Record<string, any>;
+
+  @ApiProperty({ description: 'External transaction reference' })
+  @Column({ name: 'external_reference', nullable: true })
+  externalReference: string;
+
+  @ApiProperty({ description: 'Transaction creation timestamp' })
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Transaction last update timestamp' })
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  // Relations
+  @ApiProperty({ description: 'Sender user', type: () => User })
+  @ManyToOne(() => User, { eager: true })
+  @JoinColumn({ name: 'sender_id' })
+  sender: User;
+
+  @ApiProperty({ description: 'Receiver user', type: () => User })
+  @ManyToOne(() => User, { eager: true })
+  @JoinColumn({ name: 'receiver_id' })
+  receiver: User;
+} 

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  Get,
+  UseGuards,
+  Request,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TransactionsService } from './transactions.service';
+import { Transaction } from './entities/transaction.entity';
+
+interface AuthenticatedRequest extends Request {
+  user: {
+    id: number;
+    email: string;
+    role?: string;
+  };
+}
+
+@ApiTags('Transactions')
+@Controller('transactions')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+export class TransactionsController {
+  private readonly logger = new Logger(TransactionsController.name);
+
+  constructor(private readonly transactionsService: TransactionsService) {}
+
+  @Get('my')
+  @ApiOperation({ 
+    summary: 'Get user transactions',
+    description: 'Fetch all transactions where the authenticated user is either the sender or receiver. Results are sorted by date in descending order.'
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'User transactions retrieved successfully',
+    type: [Transaction],
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized - Valid JWT token required',
+  })
+  @ApiResponse({
+    status: HttpStatus.INTERNAL_SERVER_ERROR,
+    description: 'Internal server error',
+  })
+  async getMyTransactions(@Request() req: AuthenticatedRequest): Promise<Transaction[]> {
+    const userId = req.user.id;
+    this.logger.log(`User ${userId} requesting their transactions`);
+    
+    return this.transactionsService.getUserTransactions(userId);
+  }
+} 

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TransactionsController } from './transactions.controller';
+import { TransactionsService } from './transactions.service';
+import { Transaction } from './entities/transaction.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Transaction])],
+  controllers: [TransactionsController],
+  providers: [TransactionsService],
+  exports: [TransactionsService],
+})
+export class TransactionsModule {} 

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Transaction } from './entities/transaction.entity';
+
+@Injectable()
+export class TransactionsService {
+  private readonly logger = new Logger(TransactionsService.name);
+
+  constructor(
+    @InjectRepository(Transaction)
+    private transactionRepository: Repository<Transaction>,
+  ) {}
+
+  /**
+   * Get all transactions for a specific user (both as sender and receiver)
+   * @param userId - The ID of the user
+   * @returns Promise<Transaction[]> - Array of transactions sorted by date descending
+   */
+  async getUserTransactions(userId: number): Promise<Transaction[]> {
+    this.logger.log(`Fetching transactions for user ${userId}`);
+
+    try {
+      const transactions = await this.transactionRepository.find({
+        where: [
+          { senderId: userId },
+          { receiverId: userId }
+        ],
+        relations: ['sender', 'receiver'],
+        order: {
+          createdAt: 'DESC'
+        }
+      });
+
+      this.logger.log(`Found ${transactions.length} transactions for user ${userId}`);
+      return transactions;
+    } catch (error) {
+      this.logger.error(`Error fetching transactions for user ${userId}: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a specific transaction by ID
+   * @param id - Transaction ID
+   * @returns Promise<Transaction>
+   */
+  async getTransactionById(id: string): Promise<Transaction> {
+    const transaction = await this.transactionRepository.findOne({
+      where: { id },
+      relations: ['sender', 'receiver']
+    });
+
+    if (!transaction) {
+      throw new NotFoundException(`Transaction with ID ${id} not found`);
+    }
+
+    return transaction;
+  }
+
+  /**
+   * Create a new transaction
+   * @param transactionData - Transaction data
+   * @returns Promise<Transaction>
+   */
+  async createTransaction(transactionData: Partial<Transaction>): Promise<Transaction> {
+    const transaction = this.transactionRepository.create(transactionData);
+    return this.transactionRepository.save(transaction);
+  }
+} 


### PR DESCRIPTION
# Add GET /transactions/my endpoint for user transaction history

## Description

This PR implements a new endpoint that allows authenticated users to fetch their complete transaction history, including both transactions where they are the sender and receiver. This provides users with a consolidated view of their buying and selling activity.

Closes #18 

## 🚀 Changes Implemented

- **New Endpoint**: `GET /transactions/my` 
- **Authentication**: JWT Bearer token required
- **Comprehensive Transaction History**: Returns both sent and received transactions
- **Sorted Results**: Transactions ordered by date (newest first)
- **User Relations**: Populated sender and receiver user information

## 📁 Files Added/Modified

### New Files
- `src/transactions/entities/transaction.entity.ts` - Transaction database entity
- `src/transactions/transactions.service.ts` - Business logic for transaction operations
- `src/transactions/transactions.controller.ts` - REST API controller
- `src/transactions/transactions.module.ts` - NestJS module configuration
- `src/transactions/dto/transaction-response.dto.ts` - API response DTOs


## ✅ Acceptance Criteria Met

- [x] **User Transactions**: Endpoint returns all transactions where user is sender OR receiver
- [x] **Date Sorting**: Results sorted by creation date in descending order  
- [x] **User Relations**: Sender and receiver user details populated via TypeORM relations
- [x] **Authentication**: JWT authentication enforced on all endpoints
- [x] **API Documentation**: Complete Swagger/OpenAPI documentation
- [x] **Code Standards**: Follows existing NestJS patterns and TypeScript conventions


