### PR TITLE
feat: PATCH /wallet/regenerate endpoint for secure wallet key regeneration and audit logging (Close #26)

### DIFF
--- a/src/wallet/entities/wallet-key-audit.entity.ts
+++ b/src/wallet/entities/wallet-key-audit.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity()
+export class WalletKeyAudit {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  oldPublicKey: string;
+
+  @Column()
+  oldSecretKey: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Req, UseGuards, HttpException, HttpStatus } from '@nestjs/common';
 import { WalletService } from './wallet.service';
 import { CreateWalletDto } from './dto/create-wallet.dto';
 import { UpdateWalletDto } from './dto/update-wallet.dto';
@@ -7,5 +7,22 @@ import { UpdateWalletDto } from './dto/update-wallet.dto';
 export class WalletController {
   constructor(private readonly walletService: WalletService) {}
 
- 
+  // PATCH /wallet/regenerate
+  @Patch('regenerate')
+  @UseGuards(require('../auth/guards/jwt-auth.guard').JwtAuthGuard)
+  async regenerateWalletKeys(@Req() req) {
+    // Enforce authentication (JWT guard ensures user is authenticated)
+    const user = req.user;
+    if (!user || !user.userId) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+    // Optionally: Enforce 2FA here if implemented
+
+    try {
+      const wallet = await this.walletService.regenerateWalletKeys(user.userId);
+      return { message: 'Wallet keys regenerated successfully', wallet };
+    } catch (error) {
+      throw new HttpException(error.message || 'Wallet regeneration failed', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
 }

--- a/src/wallet/wallet.module.ts
+++ b/src/wallet/wallet.module.ts
@@ -3,10 +3,11 @@ import { WalletService } from './wallet.service';
 import { WalletController } from './wallet.controller';
 import { ConfigModule } from '@nestjs/config';
 import { Wallet } from './entities/wallet.entity';
+import { WalletKeyAudit } from './entities/wallet-key-audit.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Wallet]), ConfigModule],
+  imports: [TypeOrmModule.forFeature([Wallet, WalletKeyAudit]), ConfigModule],
   controllers: [WalletController],
   providers: [WalletService],
   exports: [WalletService],

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as crypto from 'crypto';
 import { Wallet } from './entities/wallet.entity';
+import { WalletKeyAudit } from './entities/wallet-key-audit.entity';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
@@ -11,6 +12,8 @@ export class WalletService {
     @InjectRepository(Wallet)
     private walletRepository: Repository<Wallet>,
     private configService: ConfigService,
+    @InjectRepository(WalletKeyAudit)
+    private walletKeyAuditRepository: Repository<WalletKeyAudit>,
   ) {}
 
   generateKeyPair(): { publicKey: string; secretKey: string } {
@@ -50,5 +53,36 @@ export class WalletService {
   
     const cipher = crypto.createCipheriv('aes-256-ctr', key.slice(0, 32), Buffer.alloc(16, 0));
     return Buffer.concat([cipher.update(text), cipher.final()]).toString('hex');
+  }
+
+  /**
+   * Regenerate wallet keys for a user, securely replacing old keys and logging the previous keys in an audit table.
+   * @param userId - The ID of the user whose wallet keys are to be regenerated
+   * @returns The updated wallet entity
+   */
+  async regenerateWalletKeys(userId: string): Promise<Wallet> {
+    // Find the user's wallet
+    const wallet = await this.findByUserId(userId);
+    if (!wallet) {
+      throw new Error('Wallet not found for user');
+    }
+
+    // Log previous keys in audit table
+    await this.walletKeyAuditRepository.save({
+      userId,
+      oldPublicKey: wallet.publicKey,
+      oldSecretKey: wallet.secretKey, // already encrypted
+    });
+
+    // Generate new keys
+    const { publicKey, secretKey } = this.generateKeyPair();
+    const encryptedSecret = this.encrypt(secretKey);
+
+    // Update wallet with new keys
+    wallet.publicKey = publicKey;
+    wallet.secretKey = encryptedSecret;
+    await this.walletRepository.save(wallet);
+
+    return wallet;
   }
 }


### PR DESCRIPTION

## Summary

This PR implements an emergency wallet key regeneration feature for compromised Stellar wallets.

### Key Features
- **PATCH `/wallet/regenerate` endpoint:** Allows authenticated users to regenerate their wallet keys.
- **Secure Key Replacement:** New keys are generated and securely replace the old ones.
- **Audit Logging:** Previous keys are logged in the new `wallet_key_audit` table for security auditing.
- **Authentication Required:** Endpoint is protected by JWT authentication (2FA can be enforced if implemented).
- **Robust Error Handling:** Handles missing wallets and regeneration errors gracefully.

### Technical Details
- New entity: `WalletKeyAudit` for audit trail.
- Updates to `WalletService` and [WalletController](cci:2://file:///Users/macbookpro/Documents/builds/onlydust/MarketX-backend/src/wallet/wallet.controller.ts:5:0-27:1) to support regeneration and logging.
- [WalletModule](cci:2://file:///Users/macbookpro/Documents/builds/onlydust/MarketX-backend/src/wallet/wallet.module.ts:8:0-14:28) updated to register the new audit entity.

### Acceptance Criteria
- Users can regenerate wallet keys via PATCH `/wallet/regenerate`.
- New keys replace old keys securely.
- Previous keys are logged in an audit table.
- User authentication is enforced before regeneration.

---

**Close #26**

**Labels:** `nestjs`, `security`, `blockchain`, `priority-high`

---

#### Notes
- You may need to run a TypeORM migration to create the `wallet_key_audit` table.
- 2FA enforcement can be added if your auth system supports it.
