### PR TITLE
feat: add wallet balance endpoint

### DIFF
--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -7,6 +7,26 @@ import { UpdateWalletDto } from './dto/update-wallet.dto';
 export class WalletController {
   constructor(private readonly walletService: WalletService) {}
 
+  // GET /wallet/balance
+  @Get('balance')
+  @UseGuards(require('../auth/guards/jwt-auth.guard').JwtAuthGuard)
+  async getWalletBalance(@Req() req) {
+    const user = req.user;
+    if (!user || !user.userId) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    try {
+      const balance = await this.walletService.getWalletBalance(user.userId);
+      return balance;
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to fetch wallet balance',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
   // PATCH /wallet/regenerate
   @Patch('regenerate')
   @UseGuards(require('../auth/guards/jwt-auth.guard').JwtAuthGuard)


### PR DESCRIPTION
This PR implements the wallet balance endpoint as specified in #28.

Changes:
- Add GET /wallet/balance endpoint with JWT authentication
- Implement getWalletBalance service method using Stellar SDK
- Return wallet balance, currency, and publicKey
- Add proper error handling for various scenarios

The endpoint is secured and only accessible to authenticated users.
Response format:
```json
{
  "balance": "100.0000000",
  "currency": "XLM",
  "publicKey": "G..."
}
```

Close #28