### PR TITLE
feat: extend activeListings with filter and search capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /node_modules
 /build
 
+# files
+http.endpoin.http
+
 # Logs
 logs
 *.log

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { FavoritesModule } from './favorites/favorites.module';
 import { Listing } from './listing/entities/listing.entity';
 import { UsersModule } from './users/users.module';
 import { ChatModule } from './chat/chat.module';
+import { Users } from './users/users.entity';
 
 @Module({
   imports: [
@@ -29,7 +30,7 @@ import { ChatModule } from './chat/chat.module';
         username: configService.get<string>('DB_USERNAME'),
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_NAME'),
-        entities: [Listing], // or use: [__dirname + '/**/*.entity{.ts,.js}']
+        entities: [Listing, Users], // or use: [__dirname + '/**/*.entity{.ts,.js}']
         synchronize: true, // disable in production, use migrations
       }),
       inject: [ConfigService],

--- a/src/listing/entities/listing.entity.ts
+++ b/src/listing/entities/listing.entity.ts
@@ -31,6 +31,9 @@ export class Listing {
   @Column({ type: 'varchar', length: 255 })
   location: string;
 
+  @Column({ nullable: true })
+  category: string;
+
   @Column({ type: 'boolean', default: true })
   isActive: boolean;
 

--- a/src/listing/listing.controller.ts
+++ b/src/listing/listing.controller.ts
@@ -8,6 +8,7 @@ import {
   Body,
   UseGuards,
   Req,
+  Query,
 } from '@nestjs/common';
 import { CreateListingDto } from './dto/create-listing.dto';
 import { UpdateListingDto } from './dto/update-listing.dto';
@@ -22,6 +23,28 @@ export class ListingsController {
     return this.listingsService.create(dto, req.user.id);
   }
 
+  @Get('activeListings')
+  findActiveListingsPaginated(
+    @Query('take') take?: string,
+    @Query('skip') skip?: string,
+    @Query('category') category?: string,
+    @Query('location') location?: string,
+    @Query('minPrice') minPrice?: string,
+    @Query('maxPrice') maxPrice?: string,
+    @Query('q') q?: string,
+  ) {
+    return this.listingsService.findActiveListingsPaginated({
+      take: parseInt(take || '10', 10),
+      skip: parseInt(skip || '0', 10),
+      category,
+      location,
+      minPrice: minPrice ? parseFloat(minPrice) : undefined,
+      maxPrice: maxPrice ? parseFloat(maxPrice) : undefined,
+      q,
+    });
+  }
+
+  
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.listingsService.findOne(id);
@@ -36,6 +59,4 @@ export class ListingsController {
   delete(@Param('id') id: string) {
     return this.listingsService.delete(id);
   }
-
-  
 }

--- a/src/listing/listing.service.ts
+++ b/src/listing/listing.service.ts
@@ -35,13 +35,60 @@ export class ListingsService {
     return { message: 'Listing deleted' };
   }
 
-  async findActiveListingsPaginated(take = 10, skip = 0): Promise<{ listings: Listing[]; total: number }> {
-    const [listings, total] = await this.listingRepo.findAndCount({
-      where: { isActive: true },
-      order: { createdAt: 'DESC' },
+  async findActiveListingsPaginated(filters: {
+    take: number;
+    skip: number;
+    category?: string;
+    location?: string;
+    minPrice?: number;
+    maxPrice?: number;
+    q?: string;
+  }): Promise<{ listings: Listing[]; total: number }> {
+    const {
       take,
       skip,
-    });
+      category,
+      location,
+      minPrice,
+      maxPrice,
+      q,
+    } = filters;
+
+    const query = this.listingRepo
+      .createQueryBuilder('listing')
+      .where('listing.isActive = :isActive', { isActive: true })
+      .andWhere('listing.deletedAt IS NULL');
+
+    if (category) {
+      query.andWhere('listing.category = :category', { category });
+    }
+
+    if (location) {
+      query.andWhere('listing.location ILIKE :location', {
+        location: `%${location}%`,
+      });
+    }
+
+    if (minPrice !== undefined) {
+      query.andWhere('listing.price >= :minPrice', { minPrice });
+    }
+
+    if (maxPrice !== undefined) {
+      query.andWhere('listing.price <= :maxPrice', { maxPrice });
+    }
+
+    if (q) {
+      query.andWhere(
+        '(listing.title ILIKE :q OR listing.description ILIKE :q)',
+        { q: `%${q}%` },
+      );
+    }
+
+    query.orderBy('listing.createdAt', 'DESC');
+    query.take(take);
+    query.skip(skip);
+
+    const [listings, total] = await query.getManyAndCount();
 
     return { listings, total };
   }

--- a/src/market-place/market-place.controller.ts
+++ b/src/market-place/market-place.controller.ts
@@ -1,12 +1,22 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+} from '@nestjs/common';
 import { MarketPlaceService } from './market-place.service';
 import { CreateMarketPlaceDto } from './dto/create-market-place.dto';
 import { ListingsService } from 'src/listing/listing.service';
 
 @Controller('market-place')
 export class MarketPlaceController {
-  constructor(private readonly marketPlaceService: MarketPlaceService,
-              private readonly listingsService: ListingsService,
+  constructor(
+    private readonly marketPlaceService: MarketPlaceService,
+    private readonly listingsService: ListingsService,
   ) {}
 
   @Post()
@@ -21,8 +31,9 @@ export class MarketPlaceController {
     // parse query params with defaults
     const take = Math.min(parseInt(takeStr ?? '', 10) || 10, 50);
     const skip = parseInt(skipStr ?? '', 10) || 0;
-    
-    const { listings, total } = await this.listingsService.findActiveListingsPaginated(take, skip);
+
+    const { listings, total } =
+      await this.listingsService.findActiveListingsPaginated({take, skip});
 
     return {
       data: listings,


### PR DESCRIPTION
Closes #16 
- Added support for filtering active listings by category, location, price range, and keywords.
- Used TypeORM QueryBuilder for flexible dynamic filtering.
- Handled pagination via take and skip query params.

### Summary
- Users can now filter `/listings/activeListings` using:
  - category
  - location
  - price range (minPrice, maxPrice)
  - keyword search (`q`)
- Fully integrated with pagination (`take`, `skip`).

### Tech
- Uses TypeORM QueryBuilder.
- All filters are optional and dynamically applied.

### Testing
- Tested with partial, full, and no filters.
- Verified empty results return cleanly without crash.
- endpoint should be :
GET /listings/activeListings?take=10&skip=0&category=tech&location=Lagos&minPrice=100&maxPrice=500&q=ai
