### PR TITLE
feat(price): add real-time XLM/USDC price service with caching and conversion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,3 +76,5 @@ LOG_LEVEL=info
 
 # Database Logging (development only)
 DB_LOGGING=true
+
+COINGECKO_API_KEY=your_key_here   # optional, increases rate limits

--- a/package.json
+++ b/package.json
@@ -20,17 +20,6 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-
-    "@nestjs/common": "^11.0.1",
-    "@nestjs/core": "^11.0.1",
-    "@nestjs/platform-express": "^11.0.1",
-    "@nestjs/swagger": "^11.2.5",
-    "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.3",
-    "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1",
-    "swagger-ui-express": "^5.0.1"
-
     "@nestjs/axios": "^4.0.0",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.1.3",
@@ -41,16 +30,17 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.3",
-    "@nestjs/schedule": "^6.0.0",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
-    "@stellar/stellar-sdk": "^14.4.3",
+    "@stellar/stellar-sdk": "^13.3.0",
     "@types/compression": "^1.8.1",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/pdfkit": "^0.14.0",
+    "axios": "^1.13.5",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
@@ -68,12 +58,11 @@
     "redis": "^4.7.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "@stellar/stellar-sdk": "^13.3.0",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.25",
     "uuid": "^9.0.0",
     "winston": "^3.14.2",
     "winston-daily-rotate-file": "^4.7.1"
-
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -85,6 +74,7 @@
     "@nestjs/websockets": "^11.1.3",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
+    "@types/axios": "^0.9.36",
     "@types/bcrypt": "^5.0.2",
     "@types/connect": "^3.4.38",
     "@types/express": "^5.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,12 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-
 import { ProductsModule } from './products/products.module';
-
-@Module({
-  imports: [ProductsModule],
-
 import { MessagesModule } from './messages/messages.module';
 import { CommonModule } from './common/common.module';
 import { LoggerModule } from './common/logger/logger.module';
@@ -20,6 +15,8 @@ import { SecurityMiddleware } from './common/middleware/security.middleware';
 import { HealthModule } from './health/health.module';
 import { PaymentsModule } from './payments/payments.module';
 import { CustomI18nModule } from './i18n/i18n.module';
+import { PriceModule } from './price/price.module';
+
 
 @Module({
   imports: [
@@ -38,6 +35,7 @@ import { CustomI18nModule } from './i18n/i18n.module';
       migrations: ['dist/migrations/*.js'],
       migrationsRun: false,
     }),
+    PriceModule,
     MessagesModule,
     CommonModule,
     LoggerModule,
@@ -45,7 +43,6 @@ import { CustomI18nModule } from './i18n/i18n.module';
     PaymentsModule,
     CustomI18nModule,
   ],
-
   controllers: [AppController],
   providers: [
     AppService,
@@ -58,6 +55,7 @@ import { CustomI18nModule } from './i18n/i18n.module';
   ],
   exports: [AdminGuard, RolesGuard, LoggerModule],
 })
+
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(SecurityMiddleware).forRoutes('*');

--- a/src/price/dto/conversion.dto.ts
+++ b/src/price/dto/conversion.dto.ts
@@ -1,0 +1,49 @@
+import { IsEnum, IsNumber, IsPositive } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum SupportedCurrency {
+  XLM = 'XLM',
+  USDC = 'USDC',
+  USD = 'USD',
+}
+
+export class ConvertDto {
+  @ApiProperty({ enum: SupportedCurrency, example: 'XLM' })
+  @IsEnum(SupportedCurrency)
+  from: SupportedCurrency;
+
+  @ApiProperty({ enum: SupportedCurrency, example: 'USD' })
+  @IsEnum(SupportedCurrency)
+  to: SupportedCurrency;
+
+  @ApiProperty({ example: 100 })
+  @IsNumber()
+  @IsPositive()
+  amount: number;
+}
+
+export class ConversionResultDto {
+  @ApiProperty() from: string;
+  @ApiProperty() to: string;
+  @ApiProperty() amount: number;
+  @ApiProperty() result: number;
+  @ApiProperty() rate: number;
+  @ApiProperty() cachedAt: string;
+}
+
+export class RatesResponseDto {
+  @ApiProperty() 
+  XLM_USD: number;
+
+  @ApiProperty() 
+  USDC_USD: number;
+
+  @ApiProperty() 
+  XLM_USDC: number;
+
+  @ApiProperty() 
+  cachedAt: string;
+
+  @ApiProperty() 
+  source: 'live' | 'fallback';
+}

--- a/src/price/price.controller.ts
+++ b/src/price/price.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { ApiOperation, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { PriceService } from './price.service';
+import { ConvertDto, ConversionResultDto, RatesResponseDto } from './dto/conversion.dto';
+import { Public } from 'src/decorators/roles.decorator';
+
+@ApiTags('Price')
+@ApiSecurity('x-api-key')
+@Controller('price')
+export class PriceController {
+  constructor(private readonly priceService: PriceService) {}
+
+  @Public()
+  @Get('rates')
+  @ApiOperation({ summary: 'Get current XLM, USDC, and USD exchange rates' })
+  getRates(): RatesResponseDto {
+    const rates = this.priceService.getRates();
+    return {
+      ...rates,
+      cachedAt: rates.cachedAt.toISOString(),
+    };
+  }
+
+  @Post('convert')
+  @ApiOperation({ summary: 'Convert between XLM, USDC, and USD' })
+  convert(@Body() dto: ConvertDto): ConversionResultDto {
+    const { result, rate, cachedAt, source } = this.priceService.convert(
+      dto.from,
+      dto.to,
+      dto.amount,
+    );
+    return {
+      from: dto.from,
+      to: dto.to,
+      amount: dto.amount,
+      result,
+      rate,
+      cachedAt: cachedAt.toISOString(),
+      source,
+    } as any;
+  }
+}

--- a/src/price/price.module.ts
+++ b/src/price/price.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PriceService } from './price.service';
+import { PriceController } from './price.controller';
+
+@Module({
+  controllers: [PriceController],
+  providers: [PriceService],
+  exports: [PriceService],
+})
+export class PriceModule {}

--- a/src/price/price.service.spec.ts
+++ b/src/price/price.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PriceService } from './price.service';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { SupportedCurrency } from './dto/conversion.dto';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockRatesResponse = {
+  data: {
+    stellar: { usd: 0.12 },
+    'usd-coin': { usd: 1.0 },
+  },
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config: { headers: {} as any },
+} as any;
+
+describe('PriceService', () => {
+  let service: PriceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PriceService,
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue(null) } },
+      ],
+    }).compile();
+
+    service = module.get<PriceService>(PriceService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('refreshRates', () => {
+    it('should fetch and cache live rates', async () => {
+      mockedAxios.get.mockResolvedValue(mockRatesResponse);
+
+      await service.refreshRates();
+      const rates = service.getRates();
+
+      expect(rates.XLM_USD).toBe(0.12);
+      expect(rates.USDC_USD).toBe(1.0);
+      expect(rates.source).toBe('live');
+    });
+
+    it('should fall back to last known rates on API failure', async () => {
+      // First load good rates
+      mockedAxios.get.mockResolvedValueOnce(mockRatesResponse);
+      await service.refreshRates();
+
+      // Then simulate failure
+      mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
+      await service.refreshRates();
+
+      const rates = service.getRates();
+      expect(rates.source).toBe('fallback');
+      expect(rates.XLM_USD).toBe(0.12); // last known value preserved
+    });
+
+    it('should use hardcoded fallback if no rates ever loaded', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('Network error'));
+      await service.refreshRates();
+
+      const rates = service.getRates();
+      expect(rates.source).toBe('fallback');
+      expect(rates.XLM_USD).toBe(0.11); // hardcoded default
+    });
+  });
+
+  describe('convert', () => {
+    beforeEach(async () => {
+      mockedAxios.get.mockResolvedValue(mockRatesResponse);
+      await service.refreshRates();
+    });
+
+    it('should convert XLM to USD', () => {
+      const result = service.convert(SupportedCurrency.XLM, SupportedCurrency.USD, 100);
+      expect(result.result).toBeCloseTo(12, 1);
+    });
+
+    it('should convert USD to XLM', () => {
+      const result = service.convert(SupportedCurrency.USD, SupportedCurrency.XLM, 12);
+      expect(result.result).toBeCloseTo(100, 1);
+    });
+
+    it('should return 1:1 rate for same currency', () => {
+      const result = service.convert(SupportedCurrency.XLM, SupportedCurrency.XLM, 50);
+      expect(result.result).toBe(50);
+      expect(result.rate).toBe(1);
+    });
+
+    it('should convert XLM to USDC', () => {
+      const result = service.convert(SupportedCurrency.XLM, SupportedCurrency.USDC, 100);
+      expect(result.result).toBeCloseTo(12, 1);
+    });
+  });
+});

--- a/src/price/price.service.ts
+++ b/src/price/price.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import axios from 'axios';
+import { SupportedCurrency } from './dto/conversion.dto';
+
+interface RateCache {
+  XLM_USD: number;
+  USDC_USD: number;
+  XLM_USDC: number;
+  cachedAt: Date;
+  source: 'live' | 'fallback';
+}
+
+@Injectable()
+export class PriceService implements OnModuleInit {
+  private readonly logger = new Logger(PriceService.name);
+  private cache: RateCache | null = null;
+  private lastKnownRates: RateCache | null = null;
+
+  // Fallback hardcoded rates used only if no live/cached data ever loads
+  private readonly FALLBACK_RATES = {
+    XLM_USD: 0.11,
+    USDC_USD: 1.0,
+    XLM_USDC: 0.11,
+  };
+
+  private readonly COINGECKO_URL =
+    'https://api.coingecko.com/api/v3/simple/price';
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async onModuleInit() {
+    await this.refreshRates();
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async refreshRates(): Promise<void> {
+    try {
+      this.logger.log('Fetching latest crypto rates from CoinGecko...');
+
+      const apiKey = this.configService.get<string>('COINGECKO_API_KEY');
+      const headers: Record<string, string> = apiKey
+        ? { 'x-cg-demo-api-key': apiKey }
+        : {};
+
+      const { data } = await axios.get<Record<string, { usd: number }>>(this.COINGECKO_URL, {
+        headers,
+        params: {
+          ids: 'stellar,usd-coin',
+          vs_currencies: 'usd',
+        },
+        timeout: 10000,
+      });
+
+      const xlmUsd: number = data['stellar']['usd'];
+      const usdcUsd: number = data['usd-coin']['usd'];
+
+      const rates: RateCache = {
+        XLM_USD: xlmUsd,
+        USDC_USD: usdcUsd,
+        XLM_USDC: xlmUsd / usdcUsd,
+        cachedAt: new Date(),
+        source: 'live',
+      };
+
+      this.cache = rates;
+      this.lastKnownRates = rates;
+      this.logger.log(
+        `Rates updated — XLM: $${xlmUsd}, USDC: $${usdcUsd}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch rates: ${error.message}. Using fallback.`,
+      );
+      this.useFallback();
+    }
+  }
+
+  private useFallback(): void {
+    if (this.lastKnownRates) {
+      this.cache = { ...this.lastKnownRates, source: 'fallback' };
+      this.logger.warn('Using last known rates as fallback');
+    } else {
+      this.cache = {
+        ...this.FALLBACK_RATES,
+        cachedAt: new Date(),
+        source: 'fallback',
+      };
+      this.logger.warn('Using hardcoded fallback rates — no live data ever loaded');
+    }
+  }
+
+  getRates(): RateCache {
+    if (!this.cache) {
+      this.useFallback();
+    }
+    return this.cache!;
+  }
+
+  convert(from: SupportedCurrency, to: SupportedCurrency, amount: number) {
+    const rates = this.getRates();
+
+    if (from === to) {
+      return { result: amount, rate: 1, ...rates };
+    }
+
+    // Convert everything through USD as the base
+    const toUsd: Record<SupportedCurrency, number> = {
+      [SupportedCurrency.USD]: 1,
+      [SupportedCurrency.XLM]: rates.XLM_USD,
+      [SupportedCurrency.USDC]: rates.USDC_USD,
+    };
+
+    const fromUsd = toUsd[from];
+    const toUsdRate = toUsd[to];
+
+    const rate = fromUsd / toUsdRate;
+    const result = amount * rate;
+
+    return {
+      result: parseFloat(result.toFixed(6)),
+      rate: parseFloat(rate.toFixed(6)),
+      cachedAt: rates.cachedAt,
+      source: rates.source,
+    };
+  }
+}


### PR DESCRIPTION
Closes issue #129 

Implements a cryptocurrency price service with CoinGecko integration for XLM and USDC rates.

- PriceService fetches and caches rates every 5 minutes via @nestjs/schedule
- Fallback to last known rates on API failure, hardcoded defaults if never loaded
- GET /price/rates (public) and POST /price/convert (API key protected) endpoints
- Conversion routed through USD as base for XLM ↔ USDC ↔ USD support
- Unit tests covering live fetch, API failure fallback, and currency conversion