### PR TITLE
feat(wishlists): add wishlist management with price tracking and notifications

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,7 @@ import { CouponsModule } from './coupons/coupons.module';
 import { Coupon } from './coupons/entities/coupon.entity';
 import { CouponUsage } from './coupons/entities/coupon-usage.entity';
 import { AnalyticsModule } from './analytics/analytics.module';
-import { AnalyticsModule } from './analytics/analytics.module';
+import { WishlistsModule } from './wishlist/wishlists.module';
 
 @Module({
   imports: [
@@ -63,7 +63,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
     MediaModule,
     CouponsModule,
     AnalyticsModule,
-    AnalyticsModule,
+    WishlistsModule
   ],
   controllers: [AppController],
   providers: [

--- a/src/wishlist/dtos/wishlist.dto.ts
+++ b/src/wishlist/dtos/wishlist.dto.ts
@@ -1,0 +1,85 @@
+import {
+  IsString,
+  IsBoolean,
+  IsOptional,
+  IsNumber,
+  IsPositive,
+  MaxLength,
+  IsUrl,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateWishlistDto {
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPublic?: boolean;
+}
+
+export class UpdateWishlistDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPublic?: boolean;
+}
+
+export class AddWishlistItemDto {
+  @IsString()
+  productId: string;
+
+  @IsString()
+  @MaxLength(255)
+  productName: string;
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsPositive()
+  @Type(() => Number)
+  currentPrice: number;
+
+  @IsOptional()
+  @IsUrl()
+  productImageUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  productUrl?: string;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsPositive()
+  @Type(() => Number)
+  priceAlertThreshold?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  notificationsEnabled?: boolean;
+}
+
+export class UpdateWishlistItemDto {
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsPositive()
+  @Type(() => Number)
+  priceAlertThreshold?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  notificationsEnabled?: boolean;
+}

--- a/src/wishlist/entities/wishlist-item.entity.ts
+++ b/src/wishlist/entities/wishlist-item.entity.ts
@@ -1,0 +1,70 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Wishlist } from './wishlist.entity';
+
+@Entity('wishlist_items')
+@Index(['wishlistId'])
+@Index(['productId'])
+@Index(['wishlistId', 'productId'], { unique: true })
+export class WishlistItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  wishlistId: string;
+
+  @ManyToOne(() => Wishlist, (wishlist) => wishlist.items, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'wishlistId' })
+  wishlist: Wishlist;
+
+  @Column()
+  productId: string;
+
+  @Column({ length: 255 })
+  productName: string;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  priceAtAdded: number;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  currentPrice: number;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: true })
+  lowestPrice: number | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  productImageUrl: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  productUrl: string | null;
+
+  @Column({ default: true })
+  isAvailable: boolean;
+
+  /** Notify user when price drops below this threshold (null = notify on any drop) */
+  @Column({ type: 'decimal', precision: 12, scale: 2, nullable: true })
+  priceAlertThreshold: number | null;
+
+  /** Whether price-drop notifications are enabled for this item */
+  @Column({ default: true })
+  notificationsEnabled: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  priceHistory: Array<{ price: number; recordedAt: string }> | null;
+
+  @CreateDateColumn()
+  addedAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/wishlist/entities/wishlist.entity.ts
+++ b/src/wishlist/entities/wishlist.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('wishlists')
+export class Wishlist {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ default: false })
+  isPublic: boolean;
+
+  @Column({ type: 'varchar', nullable: true, unique: true })
+  shareToken: string | null;
+
+  @OneToMany(() => WishlistItem, (item) => item.wishlist, {
+    cascade: true,
+    eager: false,
+  })
+  items: WishlistItem[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+// Avoid circular import by co-locating a forward reference
+import { WishlistItem } from './wishlist-item.entity';

--- a/src/wishlist/wishlists.controller.ts
+++ b/src/wishlist/wishlists.controller.ts
@@ -1,0 +1,126 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  ParseUUIDPipe,
+  Request,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { WishlistsService } from './wishlists.service';
+import {
+  CreateWishlistDto,
+  UpdateWishlistDto,
+  AddWishlistItemDto,
+  UpdateWishlistItemDto,
+} from './dtos/wishlist.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+/**
+ * All routes under /wishlists are authenticated.
+ * The public share route /wishlists/share/:token is unauthenticated.
+ */
+@UseGuards(JwtAuthGuard)
+@Controller('wishlists')
+export class WishlistsController {
+  constructor(private readonly wishlistsService: WishlistsService) {}
+
+  @Get('share/:token')
+  getSharedWishlist(@Param('token') token: string) {
+    return this.wishlistsService.findPublicByToken(token);
+  }
+
+  /** POST /wishlists */
+  @Post()
+  create(@Request() req, @Body() dto: CreateWishlistDto) {
+    const userId = req.user?.id ?? 'dev-user'; // replace with real auth
+    return this.wishlistsService.create(userId, dto);
+  }
+
+  /** GET /wishlists */
+  @Get()
+  findAll(@Request() req) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.findAllByUser(userId);
+  }
+
+  /** GET /wishlists/:id */
+  @Get(':id')
+  findOne(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.findOne(userId, id);
+  }
+
+  /** PATCH /wishlists/:id */
+  @Patch(':id')
+  update(
+    @Request() req,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateWishlistDto,
+  ) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.update(userId, id, dto);
+  }
+
+  /** DELETE /wishlists/:id */
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.remove(userId, id);
+  }
+
+  /** POST /wishlists/:id/share — generate public share link */
+  @Post(':id/share')
+  share(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.toggleShare(userId, id, true);
+  }
+
+  /** DELETE /wishlists/:id/share — revoke public share link */
+  @Delete(':id/share')
+  unshare(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.toggleShare(userId, id, false);
+  }
+
+  /** POST /wishlists/:id/items */
+  @Post(':id/items')
+  addItem(
+    @Request() req,
+    @Param('id', ParseUUIDPipe) wishlistId: string,
+    @Body() dto: AddWishlistItemDto,
+  ) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.addItem(userId, wishlistId, dto);
+  }
+
+  /** PATCH /wishlists/:id/items/:itemId */
+  @Patch(':id/items/:itemId')
+  updateItem(
+    @Request() req,
+    @Param('id', ParseUUIDPipe) wishlistId: string,
+    @Param('itemId', ParseUUIDPipe) itemId: string,
+    @Body() dto: UpdateWishlistItemDto,
+  ) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.updateItem(userId, wishlistId, itemId, dto);
+  }
+
+  /** DELETE /wishlists/:id/items/:itemId */
+  @Delete(':id/items/:itemId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  removeItem(
+    @Request() req,
+    @Param('id', ParseUUIDPipe) wishlistId: string,
+    @Param('itemId', ParseUUIDPipe) itemId: string,
+  ) {
+    const userId = req.user?.id ?? 'dev-user';
+    return this.wishlistsService.removeItem(userId, wishlistId, itemId);
+  }
+}

--- a/src/wishlist/wishlists.module.ts
+++ b/src/wishlist/wishlists.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WishlistsController } from './wishlists.controller';
+import { WishlistsService } from './wishlists.service';
+import { Wishlist } from './entities/wishlist.entity';
+import { WishlistItem } from './entities/wishlist-item.entity';
+import { WishlistPriceScheduler } from './wishlists.scheduler';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Wishlist, WishlistItem])],
+  controllers: [WishlistsController],
+  providers: [
+    WishlistsService,
+    WishlistPriceScheduler,
+    // To plug in a real notification service:
+    // { provide: NOTIFICATION_SERVICE, useClass: YourNotificationService }
+  ],
+  exports: [WishlistsService],
+})
+export class WishlistsModule {}

--- a/src/wishlist/wishlists.scheduler.ts
+++ b/src/wishlist/wishlists.scheduler.ts
@@ -1,0 +1,67 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+// npm i @nestjs/schedule
+// import { Cron, CronExpression } from '@nestjs/schedule';
+import { WishlistItem } from './entities/wishlist-item.entity';
+import { WishlistsService } from './wishlists.service';
+
+/**
+ * Scheduler that periodically fetches current product prices
+ * and calls WishlistsService.syncPrices().
+ *
+ * To activate:
+ *  1. npm install @nestjs/schedule
+ *  2. Import ScheduleModule.forRoot() in AppModule
+ *  3. Uncomment the @Cron decorator below
+ *  4. Implement fetchCurrentPrices() to hit your product catalogue
+ */
+@Injectable()
+export class WishlistPriceScheduler {
+  private readonly logger = new Logger(WishlistPriceScheduler.name);
+
+  constructor(
+    @InjectRepository(WishlistItem)
+    private readonly itemRepo: Repository<WishlistItem>,
+    private readonly wishlistsService: WishlistsService,
+  ) {}
+
+  // @Cron(CronExpression.EVERY_HOUR)
+  async handlePriceSync() {
+    this.logger.log('Starting scheduled price sync...');
+
+    // 1. Gather all unique tracked productIds
+    const rows = await this.itemRepo
+      .createQueryBuilder('item')
+      .select('DISTINCT item.productId', 'productId')
+      .getRawMany<{ productId: string }>();
+
+    if (!rows.length) return;
+
+    const productIds = rows.map((r) => r.productId);
+
+    // 2. Fetch latest prices from your product catalogue (replace this stub)
+    const updates = await this.fetchCurrentPrices(productIds);
+
+    // 3. Sync & fire notifications
+    await this.wishlistsService.syncPrices(updates /*, notificationService */);
+  }
+
+  /**
+   * Replace this stub with a real call to your ProductsService or HTTP client.
+   * Must return { productId, newPrice, isAvailable } for each id.
+   */
+  private async fetchCurrentPrices(
+    productIds: string[],
+  ): Promise<Array<{ productId: string; newPrice: number; isAvailable: boolean }>> {
+    this.logger.warn(
+      'fetchCurrentPrices() is a stub — wire up your product service here',
+    );
+    // Example stub — replace:
+    return productIds.map((id) => ({
+      productId: id,
+      newPrice: 0, // fetch real price
+      isAvailable: true,
+    }));
+  }
+}

--- a/src/wishlist/wishlists.service.ts
+++ b/src/wishlist/wishlists.service.ts
@@ -1,0 +1,288 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { randomBytes } from 'crypto';
+import { Wishlist } from './entities/wishlist.entity';
+import { WishlistItem } from './entities/wishlist-item.entity';
+import {
+  CreateWishlistDto,
+  UpdateWishlistDto,
+  AddWishlistItemDto,
+  UpdateWishlistItemDto,
+} from './dtos/wishlist.dto';
+
+/** Injected token — implement or swap with your own notification service */
+export const NOTIFICATION_SERVICE = 'NOTIFICATION_SERVICE';
+
+export interface INotificationService {
+  sendPriceDropAlert(
+    userId: string,
+    payload: {
+      wishlistId: string;
+      wishlistName: string;
+      productId: string;
+      productName: string;
+      oldPrice: number;
+      newPrice: number;
+      savings: number;
+      savingsPercent: number;
+    },
+  ): Promise<void>;
+}
+
+const MAX_ITEMS_PER_WISHLIST = 100;
+
+@Injectable()
+export class WishlistsService {
+  private readonly logger = new Logger(WishlistsService.name);
+
+  constructor(
+    @InjectRepository(Wishlist)
+    private readonly wishlistRepo: Repository<Wishlist>,
+    @InjectRepository(WishlistItem)
+    private readonly itemRepo: Repository<WishlistItem>,
+    private readonly dataSource: DataSource,
+    // Optional: inject your notification service via token
+    // @Inject(NOTIFICATION_SERVICE) private readonly notificationService: INotificationService,
+  ) {}
+
+  async create(userId: string, dto: CreateWishlistDto): Promise<Wishlist> {
+    const wishlist = this.wishlistRepo.create({
+      userId,
+      name: dto.name,
+      description: dto.description,
+      isPublic: dto.isPublic ?? false,
+    });
+    return this.wishlistRepo.save(wishlist);
+  }
+
+  async findAllByUser(userId: string): Promise<Wishlist[]> {
+    return this.wishlistRepo.find({
+      where: { userId },
+      relations: ['items'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(userId: string, wishlistId: string): Promise<Wishlist> {
+    const wishlist = await this.wishlistRepo.findOne({
+      where: { id: wishlistId, userId },
+      relations: ['items'],
+    });
+    if (!wishlist) throw new NotFoundException('Wishlist not found');
+    return wishlist;
+  }
+
+  async findPublicByToken(shareToken: string): Promise<Wishlist> {
+    const wishlist = await this.wishlistRepo.findOne({
+      where: { shareToken, isPublic: true },
+      relations: ['items'],
+    });
+    if (!wishlist) throw new NotFoundException('Shared wishlist not found');
+    return wishlist;
+  }
+
+  async update(
+    userId: string,
+    wishlistId: string,
+    dto: UpdateWishlistDto,
+  ): Promise<Wishlist> {
+    const wishlist = await this.findOne(userId, wishlistId);
+    Object.assign(wishlist, dto);
+    return this.wishlistRepo.save(wishlist);
+  }
+
+  async remove(userId: string, wishlistId: string): Promise<void> {
+    const wishlist = await this.findOne(userId, wishlistId);
+    await this.wishlistRepo.remove(wishlist);
+  }
+
+  /** Generate or revoke a public share link */
+  async toggleShare(
+    userId: string,
+    wishlistId: string,
+    share: boolean,
+  ): Promise<Wishlist> {
+    const wishlist = await this.findOne(userId, wishlistId);
+    if (share) {
+      wishlist.isPublic = true;
+      wishlist.shareToken = randomBytes(24).toString('hex');
+    } else {
+      wishlist.isPublic = false;
+      wishlist.shareToken = null;
+    }
+    return this.wishlistRepo.save(wishlist);
+  }
+
+  async addItem(
+    userId: string,
+    wishlistId: string,
+    dto: AddWishlistItemDto,
+  ): Promise<WishlistItem> {
+    const wishlist = await this.findOne(userId, wishlistId);
+
+    const count = await this.itemRepo.count({ where: { wishlistId } });
+    if (count >= MAX_ITEMS_PER_WISHLIST) {
+      throw new BadRequestException(
+        `Wishlists support a maximum of ${MAX_ITEMS_PER_WISHLIST} items`,
+      );
+    }
+
+    const existing = await this.itemRepo.findOne({
+      where: { wishlistId, productId: dto.productId },
+    });
+    if (existing) {
+      throw new ConflictException('Product already exists in this wishlist');
+    }
+
+    const item = this.itemRepo.create({
+      wishlistId,
+      productId: dto.productId,
+      productName: dto.productName,
+      priceAtAdded: dto.currentPrice,
+      currentPrice: dto.currentPrice,
+      lowestPrice: dto.currentPrice,
+      productImageUrl: dto.productImageUrl ?? null,
+      productUrl: dto.productUrl ?? null,
+      priceAlertThreshold: dto.priceAlertThreshold ?? null,
+      notificationsEnabled: dto.notificationsEnabled ?? true,
+      priceHistory: [
+        { price: dto.currentPrice, recordedAt: new Date().toISOString() },
+      ],
+    });
+
+    return this.itemRepo.save(item);
+  }
+
+  async updateItem(
+    userId: string,
+    wishlistId: string,
+    itemId: string,
+    dto: UpdateWishlistItemDto,
+  ): Promise<WishlistItem> {
+    await this.findOne(userId, wishlistId); // ownership check
+    const item = await this.itemRepo.findOne({
+      where: { id: itemId, wishlistId },
+    });
+    if (!item) throw new NotFoundException('Wishlist item not found');
+    Object.assign(item, dto);
+    return this.itemRepo.save(item);
+  }
+
+  async removeItem(
+    userId: string,
+    wishlistId: string,
+    itemId: string,
+  ): Promise<void> {
+    await this.findOne(userId, wishlistId);
+    const item = await this.itemRepo.findOne({
+      where: { id: itemId, wishlistId },
+    });
+    if (!item) throw new NotFoundException('Wishlist item not found');
+    await this.itemRepo.remove(item);
+  }
+
+  /**
+   * Called by a scheduled job (e.g. every hour via @nestjs/schedule).
+   * Pass in the latest prices fetched from your product catalogue.
+   */
+  async syncPrices(
+    updates: Array<{ productId: string; newPrice: number; isAvailable: boolean }>,
+    notificationService?: INotificationService,
+  ): Promise<void> {
+    if (!updates.length) return;
+
+    const productIds = updates.map((u) => u.productId);
+    const priceMap = new Map(updates.map((u) => [u.productId, u]));
+
+    const items = await this.itemRepo
+      .createQueryBuilder('item')
+      .leftJoinAndSelect('item.wishlist', 'wishlist')
+      .where('item.productId IN (:...productIds)', { productIds })
+      .andWhere('item.notificationsEnabled = true')
+      .getMany();
+
+    const toSave: WishlistItem[] = [];
+    const notifications: Array<{
+      userId: string;
+      item: WishlistItem;
+      oldPrice: number;
+      newPrice: number;
+    }> = [];
+
+    for (const item of items) {
+      const update = priceMap.get(item.productId);
+      if (!update) continue;
+
+      const { newPrice, isAvailable } = update;
+      const oldPrice = Number(item.currentPrice);
+      const isPriceDrop = newPrice < oldPrice;
+
+      item.isAvailable = isAvailable;
+
+      if (newPrice !== oldPrice) {
+        item.currentPrice = newPrice;
+
+        // Append to history (keep last 90 entries)
+        const history = item.priceHistory ?? [];
+        history.push({ price: newPrice, recordedAt: new Date().toISOString() });
+        if (history.length > 90) history.shift();
+        item.priceHistory = history;
+
+        if (newPrice < Number(item.lowestPrice ?? oldPrice)) {
+          item.lowestPrice = newPrice;
+        }
+      }
+
+      toSave.push(item);
+
+      // Queue notification if price dropped and meets threshold
+      if (isPriceDrop && item.notificationsEnabled) {
+        const threshold = item.priceAlertThreshold;
+        const shouldNotify = threshold == null || newPrice <= Number(threshold);
+        if (shouldNotify) {
+          notifications.push({
+            userId: item.wishlist.userId,
+            item,
+            oldPrice,
+            newPrice,
+          });
+        }
+      }
+    }
+
+    if (toSave.length) {
+      await this.itemRepo.save(toSave);
+    }
+
+    // Fire notifications (non-blocking)
+    if (notificationService && notifications.length) {
+      await Promise.allSettled(
+        notifications.map(({ userId, item, oldPrice, newPrice }) => {
+          const savings = oldPrice - newPrice;
+          const savingsPercent = Math.round((savings / oldPrice) * 100);
+          return notificationService.sendPriceDropAlert(userId, {
+            wishlistId: item.wishlistId,
+            wishlistName: item.wishlist?.name ?? '',
+            productId: item.productId,
+            productName: item.productName,
+            oldPrice,
+            newPrice,
+            savings,
+            savingsPercent,
+          });
+        }),
+      );
+    }
+
+    this.logger.log(
+      `Price sync: updated ${toSave.length} items, fired ${notifications.length} notifications`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #131 

Adds full wishlist functionality including price tracking and notifications.

**Changes**
- `Wishlist` + `WishlistItem` entities with indexes and cascade delete
- REST endpoints: `POST /wishlists`, `GET /wishlists`, `POST /wishlists/:id/items` + full CRUD
- Price history tracked as JSONB (capped at 90 entries); lowest price always maintained
- `syncPrices()` method fires notifications on price drops, respecting per-item thresholds
- Optional public sharing via `POST /wishlists/:id/share` (unique token)
- `WishlistPriceScheduler` cron stub — wire up `fetchCurrentPrices()` to product catalogue
- TypeORM migration included

**To complete integration:** plug in `JwtAuthGuard`, implement `INotificationService`, and fill in the scheduler's `fetchCurrentPrices()` method.