### PR TITLE
feat(i18n): implement multi-language support with translations and localization

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": ["i18n/translations/**/*"]
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -16,7 +16,7 @@ export class AppController {
     @Query('name') name: string = 'User',
   ): Promise<string> {
     const locale = req['locale'] || 'en';
-    return await this.i18nService.translate('greeting', {
+    return await this.i18nService.translate('app.greeting', {
       lang: locale,
       args: { name },
     });

--- a/src/common/decorators/translate.decorator.ts
+++ b/src/common/decorators/translate.decorator.ts
@@ -1,0 +1,25 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { I18nContext } from 'nestjs-i18n';
+
+export type TranslateFn = (
+  key: string,
+  args?: Record<string, unknown>,
+) => Promise<string>;
+
+export const Translate = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): TranslateFn => {
+    const request = ctx.switchToHttp().getRequest();
+
+    return async (key: string, args?: Record<string, unknown>) => {
+      const i18n = I18nContext.current(ctx);
+      const lang = request?.user?.language || i18n?.lang || request?.locale || 'en';
+
+      const translated = await i18n?.translate(key, {
+        lang,
+        args,
+      });
+
+      return (translated as string) || key;
+    };
+  },
+);

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { LoggerService } from '../logger/logger.service';
+import { I18nContext } from 'nestjs-i18n';
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
@@ -18,8 +19,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
+    const lang =
+      (request?.user as any)?.language ||
+      I18nContext.current()?.lang ||
+      request?.['locale'] ||
+      'en';
+
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
-    let message = 'Internal Server Error';
+    let message =
+      (I18nContext.current()?.t('errors.internal_server_error', {
+        lang,
+      }) as string) || 'Internal Server Error';
     let errorDetails: any = {};
 
     // Handle HttpException

--- a/src/i18n/i18n.module.ts
+++ b/src/i18n/i18n.module.ts
@@ -1,5 +1,10 @@
 import { Module } from '@nestjs/common';
-import { I18nModule, HeaderResolver } from 'nestjs-i18n';
+import {
+  I18nModule,
+  HeaderResolver,
+  QueryResolver,
+  AcceptLanguageResolver,
+} from 'nestjs-i18n';
 import { join } from 'path';
 import { I18nService } from './i18n.service';
 
@@ -8,10 +13,14 @@ import { I18nService } from './i18n.service';
     I18nModule.forRoot({
       fallbackLanguage: 'en',
       loaderOptions: {
-        path: join(__dirname, '../../locales/'),
+        path: join(__dirname, 'translations/'),
         watch: true,
       },
-      resolvers: [{ use: HeaderResolver, options: ['accept-language'] }],
+      resolvers: [
+        { use: QueryResolver, options: ['lang'] },
+        { use: HeaderResolver, options: ['x-language', 'x-lang'] },
+        AcceptLanguageResolver,
+      ],
     }),
   ],
   providers: [I18nService],

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -1,0 +1,28 @@
+{
+  "app": {
+    "greeting": "Hello, {{name}}!"
+  },
+  "common": {
+    "validation_failed": "Input validation failed"
+  },
+  "errors": {
+    "internal_server_error": "Internal Server Error"
+  },
+  "validation": {
+    "isEmail": "{{property}} must be a valid email address",
+    "isNotEmpty": "{{property}} should not be empty",
+    "isString": "{{property}} must be a string",
+    "isUrl": "{{property}} must be a valid URL",
+    "isEnum": "{{property}} has an invalid value",
+    "minLength": "{{property}} must be at least {{constraints.0}} characters",
+    "maxLength": "{{property}} must be shorter than or equal to {{constraints.0}} characters",
+    "min": "{{property}} must not be less than {{constraints.0}}",
+    "max": "{{property}} must not be greater than {{constraints.0}}"
+  },
+  "emails": {
+    "transaction_received": {
+      "title": "Transaction Received",
+      "message": "You received {{currency}} {{amount}}"
+    }
+  }
+}

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -1,0 +1,28 @@
+{
+  "app": {
+    "greeting": "¡Hola, {{name}}!"
+  },
+  "common": {
+    "validation_failed": "La validación de entrada falló"
+  },
+  "errors": {
+    "internal_server_error": "Error interno del servidor"
+  },
+  "validation": {
+    "isEmail": "{{property}} debe ser un correo electrónico válido",
+    "isNotEmpty": "{{property}} no debe estar vacío",
+    "isString": "{{property}} debe ser una cadena de texto",
+    "isUrl": "{{property}} debe ser una URL válida",
+    "isEnum": "{{property}} tiene un valor inválido",
+    "minLength": "{{property}} debe tener al menos {{constraints.0}} caracteres",
+    "maxLength": "{{property}} debe tener como máximo {{constraints.0}} caracteres",
+    "min": "{{property}} no debe ser menor que {{constraints.0}}",
+    "max": "{{property}} no debe ser mayor que {{constraints.0}}"
+  },
+  "emails": {
+    "transaction_received": {
+      "title": "Transacción recibida",
+      "message": "Recibiste {{currency}} {{amount}}"
+    }
+  }
+}

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -1,0 +1,28 @@
+{
+  "app": {
+    "greeting": "Bonjour, {{name}} !"
+  },
+  "common": {
+    "validation_failed": "La validation des données a échoué"
+  },
+  "errors": {
+    "internal_server_error": "Erreur interne du serveur"
+  },
+  "validation": {
+    "isEmail": "{{property}} doit être une adresse e-mail valide",
+    "isNotEmpty": "{{property}} ne doit pas être vide",
+    "isString": "{{property}} doit être une chaîne de caractères",
+    "isUrl": "{{property}} doit être une URL valide",
+    "isEnum": "{{property}} a une valeur invalide",
+    "minLength": "{{property}} doit contenir au moins {{constraints.0}} caractères",
+    "maxLength": "{{property}} doit contenir au maximum {{constraints.0}} caractères",
+    "min": "{{property}} ne doit pas être inférieur à {{constraints.0}}",
+    "max": "{{property}} ne doit pas être supérieur à {{constraints.0}}"
+  },
+  "emails": {
+    "transaction_received": {
+      "title": "Transaction reçue",
+      "message": "Vous avez reçu {{currency}} {{amount}}"
+    }
+  }
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -6,11 +6,15 @@ import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
 import { NotificationEventListener } from './listeners/notification-event.listener';
 import { NotificationEntity } from './notification.entity';
+import { NotificationPreferencesEntity } from './notification-preferences.entity';
+import { Users } from '../users/users.entity';
+import { CustomI18nModule } from '../i18n/i18n.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([NotificationEntity]),
+    TypeOrmModule.forFeature([NotificationEntity, NotificationPreferencesEntity, Users]),
     EventEmitterModule.forRoot(),
+    CustomI18nModule,
   ],
   controllers: [NotificationsController],
   providers: [

--- a/src/users/dto/create-user-dto.dto.ts
+++ b/src/users/dto/create-user-dto.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsEmail,
+  IsIn,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -34,4 +35,10 @@ export class CreateUserDto {
   @IsOptional()
   @IsString()
   avatarUrl?: string;
+
+  @ApiProperty({ example: 'en', enum: ['en', 'es', 'fr'], required: false })
+  @IsOptional()
+  @IsString()
+  @IsIn(['en', 'es', 'fr'])
+  language?: string;
 }

--- a/src/users/dto/update-profile.dto.ts
+++ b/src/users/dto/update-profile.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsIn,
   IsOptional,
   IsString,
   IsUrl,
@@ -45,5 +46,6 @@ export class UpdateProfileDto {
   })
   @IsOptional()
   @IsString()
+  @IsIn(['en', 'es', 'fr'])
   language?: string;
 }

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -42,7 +42,7 @@ export class Users {
   @Column({ nullable: true })
   avatarUrl: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, default: 'en', length: 5 })
   language: string;
 
   @Column({ default: true })

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -56,7 +56,7 @@ export class UsersService {
       user.avatarUrl = updateProfileDto.avatarUrl;
     }
     if (updateProfileDto.language !== undefined) {
-      user.language = updateProfileDto.language;
+      user.language = updateProfileDto.language.toLowerCase();
     }
 
     // Save and return updated user


### PR DESCRIPTION
This closes #142

- Adds `nestjs-i18n` language resolution via query/header/Accept-Language in i18n.module.ts.
- Introduces translation resources for English, Spanish, and French in en.json, es.json, fr.json.
- Localizes validation error output in validation.pipe.ts and adds translation helper decorator in translate.decorator.ts.
- Adds/validates per-user language preference (`en|es|fr`) in users.entity.ts, create-user-dto.dto.ts, update-profile.dto.ts, users.service.ts.
- Localizes notification/email template text using user language in notifications.service.ts and module wiring in notifications.module.ts.
- Ensures i18n assets are copied at build time in nest-cli.json.