### PR TITLE
feat: Enforce Order State Machine via TypeORM Event Listeners

### DIFF
--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import {
   ArrayMinSize,
@@ -11,7 +12,6 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { SanitizeString } from '../../common/transformers/sanitize-string.transformer';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SupportedCurrency } from '../../products/services/pricing.service';
 
 export enum OrderStatus {
@@ -19,6 +19,7 @@ export enum OrderStatus {
   PAID = 'paid',
   SHIPPED = 'shipped',
   DELIVERED = 'delivered',
+  COMPLETED = 'completed',
   CANCELLED = 'cancelled',
 }
 

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -1,6 +1,12 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
-import { OrderStatus } from '../dto/create-order.dto';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { SupportedCurrency } from '../../products/services/pricing.service';
+import { OrderStatus } from '../dto/create-order.dto';
 
 @Entity()
 export class Order {

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,16 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { OrdersService } from './orders.service';
-import { OrdersController } from './orders.controller';
-import { Order } from './entities/order.entity';
-import { ProductsModule } from '../products/products.module';
 import { CouponsModule } from '../coupons/coupons.module';
 import { InventoryModule } from '../inventory/inventory.module';
+import { ProductsModule } from '../products/products.module';
+import { Order } from './entities/order.entity';
+import { OrdersController } from './orders.controller';
+import { OrdersService } from './orders.service';
+import { OrderStateSubscriber } from './subscribers/order-state.subscriber';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order]), ProductsModule, CouponsModule, InventoryModule],
+  imports: [
+    TypeOrmModule.forFeature([Order]),
+    ProductsModule,
+    CouponsModule,
+    InventoryModule,
+  ],
   controllers: [OrdersController],
-  providers: [OrdersService],
+  providers: [OrdersService, OrderStateSubscriber],
   exports: [OrdersService],
 })
 export class OrdersModule {}

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,26 +1,20 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
-  BadRequestException,
 } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Order } from './entities/order.entity';
+import { DataSource, Repository } from 'typeorm';
+import { InventoryService } from '../inventory/inventory.service';
+import { OrderUpdatedEvent } from '../notifications/events/order.events';
+import { PricingService } from '../products/services/pricing.service';
 import {
   CreateOrderDto,
   OrderStatus,
   UpdateOrderStatusDto,
 } from './dto/create-order.dto';
-import {
-  PricingService,
-  SupportedCurrency,
-} from '../products/services/pricing.service';
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import {
-  OrderCreatedEvent,
-  OrderUpdatedEvent,
-} from '../notifications/events/order.events';
-import { InventoryService } from '../inventory/inventory.service';
+import { Order } from './entities/order.entity';
 
 @Injectable()
 export class OrdersService {
@@ -114,15 +108,6 @@ export class OrdersService {
     const order = await this.findOne(id);
     const previousStatus = order.status;
 
-    // Validate state transition
-    if (
-      !this.isValidStateTransition(order.status, updateOrderStatusDto.status)
-    ) {
-      throw new BadRequestException(
-        `Invalid state transition from ${order.status} to ${updateOrderStatusDto.status}`,
-      );
-    }
-
     // Handle inventory based on status change
     if (updateOrderStatusDto.status === OrderStatus.PAID) {
       await this.inventoryService.confirmOrder(order);
@@ -156,24 +141,5 @@ export class OrdersService {
     );
 
     return updatedOrder;
-  }
-
-
-
-  private isValidStateTransition(
-    currentStatus: OrderStatus,
-    newStatus: OrderStatus,
-  ): boolean {
-    // Define valid state transitions
-    const validTransitions: { [key in OrderStatus]: OrderStatus[] } = {
-      [OrderStatus.PENDING]: [OrderStatus.PAID, OrderStatus.CANCELLED],
-      [OrderStatus.PAID]: [OrderStatus.SHIPPED, OrderStatus.CANCELLED],
-      [OrderStatus.SHIPPED]: [OrderStatus.DELIVERED, OrderStatus.CANCELLED],
-      [OrderStatus.DELIVERED]: [],
-      [OrderStatus.CANCELLED]: [],
-    };
-
-    const allowedTransitions = validTransitions[currentStatus] || [];
-    return allowedTransitions.includes(newStatus);
   }
 }

--- a/src/orders/subscribers/order-state.subscriber.ts
+++ b/src/orders/subscribers/order-state.subscriber.ts
@@ -1,0 +1,56 @@
+import { EntitySubscriberInterface, EventSubscriber, InsertEvent, UpdateEvent } from 'typeorm';
+import { Order } from '../entities/order.entity';
+import { OrderStatus } from '../dto/create-order.dto';
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+
+@EventSubscriber()
+export class OrderStateSubscriber implements EntitySubscriberInterface<Order> {
+  // Define strict state transition dictionary
+  private static readonly VALID_STATE_TRANSITIONS: { [key in OrderStatus]: OrderStatus[] } = {
+    [OrderStatus.PENDING]: [OrderStatus.PAID, OrderStatus.CANCELLED],
+    [OrderStatus.PAID]: [OrderStatus.SHIPPED, OrderStatus.CANCELLED],
+    [OrderStatus.SHIPPED]: [OrderStatus.DELIVERED, OrderStatus.CANCELLED],
+    [OrderStatus.DELIVERED]: [OrderStatus.COMPLETED],
+    [OrderStatus.CANCELLED]: [],
+    [OrderStatus.COMPLETED]: [],
+  };
+
+  listenTo() {
+    return Order;
+  }
+
+  async beforeInsert(event: InsertEvent<Order>): Promise<void> {
+    // For new orders, ensure status starts as PENDING
+    if (event.entity.status && event.entity.status !== OrderStatus.PENDING) {
+      throw new BadRequestException(
+        `New orders must start with status ${OrderStatus.PENDING}. Invalid status: ${event.entity.status}`
+      );
+    }
+  }
+
+  async beforeUpdate(event: UpdateEvent<Order>): Promise<void> {
+    if (!event.entity || !event.databaseEntity) {
+      return;
+    }
+
+    const newStatus = event.entity.status;
+    const oldStatus = event.databaseEntity.status;
+
+    // Skip validation if status hasn't changed
+    if (!newStatus || newStatus === oldStatus) {
+      return;
+    }
+
+    // Validate state transition
+    if (!this.isValidStateTransition(oldStatus, newStatus)) {
+      throw new InternalServerErrorException(
+        `Illegal state transition attempt: ${oldStatus} -> ${newStatus}. This violates the order state machine.`
+      );
+    }
+  }
+
+  private isValidStateTransition(currentStatus: OrderStatus, newStatus: OrderStatus): boolean {
+    const allowedTransitions = OrderStateSubscriber.VALID_STATE_TRANSITIONS[currentStatus] || [];
+    return allowedTransitions.includes(newStatus);
+  }
+}


### PR DESCRIPTION
- Add COMPLETED status to OrderStatus enum for complete lifecycle
- Implement OrderStateSubscriber with strict state transition validation
- Define valid state transitions: Pending -> Paid -> Shipped -> Delivered -> Completed
- Prevent illegal jumps like Shipped -> Pending with InternalServerError
- Register subscriber in OrdersModule to enforce at database level
- Remove duplicate validation logic from OrdersService
- Ensure new orders start with PENDING status via @BeforeInsert

Closes #209