### PR TITLE
fix: dockerfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,108 @@
+name: CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Deploy to AWS ECS (rolling, zero-downtime)
+  # ──────────────────────────────────────────────
+  deploy-ecs:
+    name: Build & Deploy → AWS ECS
+    runs-on: ubuntu-latest
+    # Remove this `if` and delete the heroku job below if you only use ECS
+    if: ${{ vars.DEPLOY_TARGET == 'ecs' || vars.DEPLOY_TARGET == '' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag & push image to ECR
+        id: build-image
+        env:
+          ECR_REGISTRY:   ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG:      ${{ github.sha }}
+        run: |
+          docker build \
+            --build-arg NODE_ENV=production \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Download current ECS task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ secrets.ECS_TASK_DEFINITION }} \
+            --query taskDefinition \
+            > task-definition.json
+
+      - name: Render new ECS task definition with fresh image
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name:  ${{ secrets.ECS_CONTAINER_NAME }}
+          image:           ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy to ECS (rolling zero-downtime)
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition:  ${{ steps.task-def.outputs.task-definition }}
+          service:          ${{ secrets.ECS_SERVICE }}
+          cluster:          ${{ secrets.ECS_CLUSTER }}
+          wait-for-service-stability: true   # blocks until old tasks drain
+
+  # ──────────────────────────────────────────────
+  # Deploy to Heroku (rolling dyno restart)
+  # ──────────────────────────────────────────────
+  deploy-heroku:
+    name: Build & Deploy → Heroku
+    runs-on: ubuntu-latest
+    if: ${{ vars.DEPLOY_TARGET == 'heroku' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Heroku Container Registry
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          echo "$HEROKU_API_KEY" | docker login \
+            --username=_ \
+            --password-stdin \
+            registry.heroku.com
+
+      - name: Build & push image to Heroku registry
+        env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+        run: |
+          docker build \
+            --build-arg NODE_ENV=production \
+            -t registry.heroku.com/$HEROKU_APP_NAME/web \
+            .
+          docker push registry.heroku.com/$HEROKU_APP_NAME/web
+
+      - name: Release new image on Heroku (rolling restart)
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+        run: |
+          heroku container:release web --app $HEROKU_APP_NAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: Lint, Format & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests with coverage
+        run: npm run test -- --coverage --coverageReporters=lcov --coverageReporters=text
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true
+          comment: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: '3.9'
+
+services:
+  # ── NestJS API ────────────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    container_name: marketx_api
+    restart: unless-stopped
+    ports:
+      - '3000:3000'
+    environment:
+      NODE_ENV:    ${NODE_ENV:-development}
+      PORT:        3000
+      DB_HOST:     postgres
+      DB_PORT:     5432
+      DB_NAME:     ${DB_NAME:-marketx}
+      DB_USER:     ${DB_USER:-marketx_user}
+      DB_PASSWORD: ${DB_PASSWORD:-secret}
+      REDIS_HOST:  redis
+      REDIS_PORT:  6379
+      JWT_SECRET:  ${JWT_SECRET}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - marketx_net
+
+  # ── PostgreSQL 15 ─────────────────────────────────────────
+  postgres:
+    image: postgres:15-alpine
+    container_name: marketx_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB:       ${DB_NAME:-marketx}
+      POSTGRES_USER:     ${DB_USER:-marketx_user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-secret}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test:     ['CMD-SHELL', 'pg_isready -U ${DB_USER:-marketx_user} -d ${DB_NAME:-marketx}']
+      interval: 10s
+      timeout:  5s
+      retries:  5
+    networks:
+      - marketx_net
+
+  # ── Redis ─────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: marketx_redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test:     ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout:  5s
+      retries:  5
+    networks:
+      - marketx_net
+
+# ── Persistent Volumes ────────────────────────────────────────
+volumes:
+  postgres_data:
+  redis_data:
+
+# ── Network ───────────────────────────────────────────────────
+networks:
+  marketx_net:
+    driver: bridge

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,45 @@
+# ─────────────────────────────────────────────────────────────
+# Stage 1 — Builder
+# Compiles TypeScript and prunes dev dependencies
+# ─────────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies (including devDependencies needed to build)
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and compile
+COPY . .
+RUN npm run build          # outputs to /app/dist
+
+
+# ─────────────────────────────────────────────────────────────
+# Stage 2 — Production
+# Lean runtime image; strips everything not needed at runtime
+# ─────────────────────────────────────────────────────────────
+FROM node:20-alpine AS production
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+WORKDIR /app
+
+# Only install production dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Pull compiled artefacts from the builder stage
+COPY --from=builder /app/dist ./dist
+
+# Drop to non-root user for security
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- http://localhost:3000/health || exit 1
+
+CMD ["node", "dist/main.js"]

--- a/src/admin/admin-tax-export.controller.ts
+++ b/src/admin/admin-tax-export.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminTaxExportService } from './admin-tax-export.service';
+import { TaxExportRequestDto } from './dtos/tax-export-request.dto';
+import { RolesGuard } from '../guards/roles.guard';
+import { Roles } from '../decorators/roles.decorator';
+
+@Controller('admin')
+@UseGuards(RolesGuard)
+export class AdminTaxExportController {
+  constructor(private readonly taxExportService: AdminTaxExportService) {}
+
+  /**
+   * POST /admin/export-tax-data
+   * Accepts the request immediately (202) and queues a background job
+   * that builds the CSV, uploads it to S3, and emails a signed URL.
+   */
+  @Post('export-tax-data')
+  @Roles('ADMIN')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async exportTaxData(@Body() dto: TaxExportRequestDto) {
+    const jobId = await this.taxExportService.queueExport(dto);
+    return {
+      message:
+        'Export job accepted. You will receive an email with the download link once it is ready.',
+      jobId,
+    };
+  }
+}

--- a/src/admin/admin-tax-export.service.ts
+++ b/src/admin/admin-tax-export.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { MailerService } from '@nestjs-modules/mailer';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { randomUUID } from 'crypto';
+import { stringify } from 'csv-stringify/sync';
+
+import { Order } from '../orders/entities/order.entity';
+import { TaxExportRequestDto } from './dtos/tax-export-request.dto';
+
+@Injectable()
+export class AdminTaxExportService {
+  private readonly logger = new Logger(AdminTaxExportService.name);
+  private readonly s3: S3Client;
+  private readonly bucket: string;
+
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>,
+    private readonly config: ConfigService,
+    private readonly mailer: MailerService,
+  ) {
+    this.s3 = new S3Client({
+      region: this.config.getOrThrow<string>('AWS_REGION'),
+      credentials: {
+        accessKeyId:     this.config.getOrThrow<string>('AWS_ACCESS_KEY_ID'),
+        secretAccessKey: this.config.getOrThrow<string>('AWS_SECRET_ACCESS_KEY'),
+      },
+    });
+    this.bucket = this.config.getOrThrow<string>('TAX_EXPORT_S3_BUCKET');
+  }
+
+  /**
+   * Enqueues the export job and returns a job ID immediately.
+   * The heavy work runs in a detached async task so the HTTP
+   * response is not blocked.
+   */
+  async queueExport(dto: TaxExportRequestDto): Promise<string> {
+    const jobId = randomUUID();
+    // Fire-and-forget — intentionally not awaited
+    this.runExport(jobId, dto).catch((err) =>
+      this.logger.error(`Tax export job ${jobId} failed`, err),
+    );
+    return jobId;
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // Private — background worker
+  // ─────────────────────────────────────────────────────────
+
+  private async runExport(
+    jobId: string,
+    dto: TaxExportRequestDto,
+  ): Promise<void> {
+    this.logger.log(`[${jobId}] Starting tax export for seller ${dto.sellerId}`);
+
+    // 1. Fetch all matching orders in paginated chunks to avoid OOM
+    const orders = await this.fetchOrdersInChunks(dto);
+    this.logger.log(`[${jobId}] Fetched ${orders.length} orders`);
+
+    // 2. Build CSV
+    const csv = this.buildCsv(orders);
+
+    // 3. Upload to S3 (cold-storage / Glacier-IA class)
+    const s3Key = `tax-exports/${dto.sellerId}/${jobId}.csv`;
+    await this.uploadToS3(s3Key, csv);
+    this.logger.log(`[${jobId}] Uploaded to s3://${this.bucket}/${s3Key}`);
+
+    // 4. Generate a 24-hour pre-signed download URL
+    const signedUrl = await this.createSignedUrl(s3Key);
+
+    // 5. Email the seller
+    await this.emailSeller(dto.sellerEmail, signedUrl, jobId);
+    this.logger.log(`[${jobId}] Email dispatched to ${dto.sellerEmail}`);
+  }
+
+  private async fetchOrdersInChunks(dto: TaxExportRequestDto): Promise<Order[]> {
+    const CHUNK_SIZE = 1_000;
+    const results: Order[] = [];
+    let skip = 0;
+
+    while (true) {
+      const chunk = await this.orderRepo.find({
+        where: {
+          sellerId: dto.sellerId,
+          createdAt: Between(new Date(dto.startDate), new Date(dto.endDate)),
+        },
+        order: { createdAt: 'ASC' },
+        take: CHUNK_SIZE,
+        skip,
+      });
+
+      results.push(...chunk);
+      if (chunk.length < CHUNK_SIZE) break;
+      skip += CHUNK_SIZE;
+    }
+
+    return results;
+  }
+
+  private buildCsv(orders: Order[]): Buffer {
+    const rows = orders.map((o) => ({
+      order_id:        o.id,
+      created_at:      o.createdAt.toISOString(),
+      seller_id:       o.sellerId,
+      buyer_id:        o.buyerId,
+      subtotal:        o.subtotal,
+      tax_amount:      o.taxAmount,
+      total:           o.total,
+      currency:        o.currency,
+      status:          o.status,
+      payment_method:  o.paymentMethod,
+    }));
+
+    const csv = stringify(rows, { header: true });
+    return Buffer.from(csv, 'utf-8');
+  }
+
+  private async uploadToS3(key: string, body: Buffer): Promise<void> {
+    await this.s3.send(
+      new PutObjectCommand({
+        Bucket:              this.bucket,
+        Key:                 key,
+        Body:                body,
+        ContentType:         'text/csv',
+        StorageClass:        'STANDARD_IA', // cold storage cost tier
+        ServerSideEncryption: 'AES256',
+      }),
+    );
+  }
+
+  private async createSignedUrl(key: string): Promise<string> {
+    const command = new GetObjectCommand({ Bucket: this.bucket, Key: key });
+    return getSignedUrl(this.s3, command, { expiresIn: 86_400 }); // 24 h
+  }
+
+  private async emailSeller(
+    email: string,
+    downloadUrl: string,
+    jobId: string,
+  ): Promise<void> {
+    await this.mailer.sendMail({
+      to:      email,
+      subject: 'Your tax data export is ready',
+      html: `
+        <p>Your tax data export (Job ID: <strong>${jobId}</strong>) has been processed.</p>
+        <p>
+          <a href="${downloadUrl}">Download your CSV</a>
+          — link expires in <strong>24 hours</strong>.
+        </p>
+        <p>If you did not request this export, please contact support immediately.</p>
+      `,
+    });
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,25 +1,38 @@
-// src/admin/admin.module.ts
-
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigModule } from '@nestjs/config';
+import { MailerModule } from '@nestjs-modules/mailer';
+
 import { AdminController } from './admin.controller';
 import { AdminFraudController } from './admin-fraud.controller';
 import { AdminEscrowController } from './admin-escrow.controller';
-import { Order } from '../orders/entities/order.entity';
-import { UsersModule } from 'src/Authentication/user.module';
+import { AdminTaxExportController } from './admin-tax-export.controller';
+
 import { AdminService } from './admin.service';
+import { AdminWebhookService } from './admin-webhook.service';
+import { AdminTaxExportService } from './admin-tax-export.service';
+
+import { Order } from '../orders/entities/order.entity';
 import { User } from 'src/profile/user.entity';
 import { FraudAlert } from '../fraud/entities/fraud-alert.entity';
-import { AdminWebhookService } from './admin-webhook.service';
-import { HttpModule } from '@nestjs/axios';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Order, FraudAlert]), // import entities used by AdminService
+    ConfigModule,
+    TypeOrmModule.forFeature([User, Order, FraudAlert]),
     HttpModule,
+    // MailerModule is expected to be configured globally in AppModule
+    // (MailerModule.forRootAsync({ ... })). No re-import needed here
+    // unless you want a module-scoped override.
   ],
-  controllers: [AdminController, AdminFraudController],
-  providers: [AdminService, AdminWebhookService],
-  exports: [AdminService, AdminWebhookService],
+  controllers: [
+    AdminController,
+    AdminFraudController,
+    // AdminEscrowController,   // uncomment once the escrow module is ready
+    AdminTaxExportController,
+  ],
+  providers: [AdminService, AdminWebhookService, AdminTaxExportService],
+  exports: [AdminService, AdminWebhookService, AdminTaxExportService],
 })
 export class AdminModule {}

--- a/src/admin/dtos/tax-export-request.dto.ts
+++ b/src/admin/dtos/tax-export-request.dto.ts
@@ -1,0 +1,18 @@
+import { IsDateString, IsEmail, IsUUID } from 'class-validator';
+ 
+export class TaxExportRequestDto {
+  @IsUUID()
+  sellerId: string;
+ 
+  @IsEmail()
+  sellerEmail: string;
+ 
+  /** ISO-8601 date string, e.g. "2020-01-01" */
+  @IsDateString()
+  startDate: string;
+ 
+  /** ISO-8601 date string, e.g. "2024-12-31" */
+  @IsDateString()
+  endDate: string;
+}
+ 


### PR DESCRIPTION
feat: DevOps foundations + Tax Export Engine — closes #252, #253, #254, #255
What this PR does
This single PR ships all four infrastructure and feature issues in one coherent pass so dependent pieces (Docker → CI → CD → Export) land together.

#254 — CI Pipeline (.github/workflows/ci.yml)
Every PR targeting main spins up a fresh Ubuntu runner, installs deps strictly via npm ci, then gates the merge on three serial checks: format:check → lint → test. Coverage is collected as LCOV and pushed to Codecov which auto-comments the diff on the PR. A failed check blocks the merge at the branch-protection level.
Required secret: CODECOV_TOKEN

#255 — CD Pipeline (.github/workflows/cd.yml)
Fires exclusively on a merge to main. Supports both deployment targets behind a single repo variable (vars.DEPLOY_TARGET = ecs | heroku):

ECS path — logs into ECR, builds & pushes a SHA-tagged image, re-renders the task definition with the new image, then calls amazon-ecs-deploy-task-definition with wait-for-service-stability: true for native rolling zero-downtime replacement.
Heroku path — pushes to the Heroku Container Registry and releases via heroku container:release, which performs a rolling dyno restart with no downtime.

All secrets (AWS_*, ECR_*, ECS_*, HEROKU_*) are read from GitHub Secrets — no credentials in code.

#253 — Multi-stage Containerisation (Dockerfile + docker-compose.yml)
Dockerfile uses two named stages:

builder — full node:20-alpine with devDeps to compile TypeScript
production — fresh node:20-alpine, only production deps copied in, non-root user, HEALTHCHECK included. Final image targets < 250 MB.

docker-compose.yml defines three services with dependency health-checks so the API only starts after Postgres and Redis pass their respective probes. docker-compose up is the single command to boot the full stack locally.

#252 — Tax Compliance Bulk Export Engine

POST /admin/export-tax-data returns 202 Accepted immediately with a jobId.
A detached background worker (fire-and-forget async) fetches orders in 1 000-row chunks (prevents OOM on large ledgers), serialises to CSV via csv-stringify, uploads to S3 with STANDARD_IA storage class + AES256 encryption, then generates a 24-hour pre-signed URL and emails it to the seller via @nestjs-modules/mailer.
admin.module.ts is updated to register AdminTaxExportController and AdminTaxExportService.

Required secrets/env vars: AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, TAX_EXPORT_S3_BUCKET, mailer config.

Testing

CI workflow is validated by the existing Jest suite on every PR.
Tax export: unit-test AdminTaxExportService by mocking OrderRepository, S3Client, and MailerService; assert 202 response and that queueExport is called once.

Closes #252
closes #253
closes #254
closes #255 