### PR TITLE
feat(auth): implement typed OAuth profile contract

### DIFF
--- a/docs/OAUTH_PROFILE_CONTRACT.md
+++ b/docs/OAUTH_PROFILE_CONTRACT.md
@@ -1,0 +1,352 @@
+# OAuth Profile Contract Implementation
+
+## Overview
+
+This document describes the implementation of a strict, typed OAuth profile contract that ensures consistent handling of third-party authentication data across the application.
+
+## Problem Statement
+
+Previously, OAuth user creation flows in the authentication service referenced missing profile types and used loosely typed payloads (`any`). This created several risks:
+
+1. **Type Safety**: No compile-time validation of OAuth profile structure
+2. **Runtime Safety**: Malformed profiles could pass through to user creation
+3. **Maintainability**: Unclear contract between strategies and auth service
+4. **Developer Experience**: No IDE support or documentation for profile structure
+
+## Solution
+
+### 1. OAuth Profile Contract (`OAuthProfile` Interface)
+
+A strict TypeScript interface that defines the required structure for all OAuth profiles:
+
+```typescript
+export interface OAuthProfile {
+  provider: OAuthProvider;
+  providerId: string;
+  email: string;
+  name: string;
+  avatarUrl?: string;
+}
+```
+
+**Fields:**
+
+- **provider** (`OAuthProvider` enum): The OAuth provider identifier (google, github)
+- **providerId** (`string`): The unique user ID from the OAuth provider
+- **email** (`string`): The user's email address
+- **name** (`string`): The user's display name
+- **avatarUrl** (`string`, optional): The user's profile picture URL
+
+### 2. Supported Providers
+
+```typescript
+export enum OAuthProvider {
+  GOOGLE = 'google',
+  GITHUB = 'github',
+}
+```
+
+New providers can be added by:
+1. Adding to the enum
+2. Adding configuration to `OAUTH_PROVIDER_CONFIG`
+3. Creating a new Passport strategy
+4. Adding validation tests
+
+### 3. Validation Functions
+
+#### `isSupportedOAuthProvider(provider: string): provider is OAuthProvider`
+
+Type guard that validates if a string is a supported OAuth provider:
+
+```typescript
+if (isSupportedOAuthProvider(provider)) {
+  // provider is now known to be OAuthProvider type
+}
+```
+
+#### `isValidOAuthProfile(profile: any): profile is OAuthProfile`
+
+Type guard that validates an entire profile object:
+
+```typescript
+if (isValidOAuthProfile(profile)) {
+  // profile is now known to be OAuthProfile type
+}
+```
+
+#### `validateOAuthProfile(profile: any): asserts profile is OAuthProfile`
+
+Assertion function that throws a descriptive error if validation fails:
+
+```typescript
+try {
+  validateOAuthProfile(profile);
+  // profile is now known to be OAuthProfile type
+} catch (error) {
+  // Handle validation error
+}
+```
+
+#### `createOAuthProfile(...): OAuthProfile`
+
+Factory function that creates and validates a profile in one step:
+
+```typescript
+const profile = createOAuthProfile(
+  OAuthProvider.GOOGLE,
+  'google-123',
+  'user@example.com',
+  'John Doe',
+  'https://example.com/avatar.jpg',
+);
+```
+
+### 4. Provider Configuration
+
+Metadata about supported OAuth providers:
+
+```typescript
+export const OAUTH_PROVIDER_CONFIG = {
+  google: {
+    displayName: 'Google',
+    scope: ['email', 'profile'],
+  },
+  github: {
+    displayName: 'GitHub',
+    scope: ['user:email'],
+  },
+};
+```
+
+## Implementation Details
+
+### Auth Service (`findOrCreateOAuthUser` Method)
+
+The method now enforces strict typing and validation:
+
+```typescript
+async findOrCreateOAuthUser(profile: OAuthProfile): Promise<string> {
+  // Validate profile against contract
+  try {
+    validateOAuthProfile(profile);
+  } catch (error) {
+    throw new BadRequestException(
+      `Invalid OAuth profile: ${error.message}`,
+    );
+  }
+
+  const { provider, providerId, email, name, avatarUrl } = profile;
+  // ... rest of implementation
+}
+```
+
+**Benefits:**
+
+- Compile-time type checking
+- Runtime validation with descriptive errors
+- Ensures only valid profiles reach user creation logic
+- Prevents malformed data from being persisted
+
+### Google Strategy
+
+Normalizes Google's profile response and creates a typed profile:
+
+```typescript
+async validate(
+  _accessToken: string,
+  _refreshToken: string,
+  profile: Profile,
+  done: VerifyCallback,
+): Promise<void> {
+  try {
+    const { id, displayName, emails, photos } = profile;
+    
+    const oauthProfile = createOAuthProfile(
+      OAuthProvider.GOOGLE,
+      id,
+      emails?.[0]?.value ?? '',
+      displayName ?? 'Google User',
+      photos?.[0]?.value,
+    );
+
+    const jwt = await this.authService.findOrCreateOAuthUser(oauthProfile);
+    done(null, { accessToken: jwt });
+  } catch (err) {
+    done(err instanceof Error ? err : new BadRequestException(...));
+  }
+}
+```
+
+**Key Changes:**
+
+- Uses `createOAuthProfile` factory function
+- Provides type-safe provider enum
+- Better error handling with descriptive messages
+- Handles optional fields gracefully
+
+### GitHub Strategy
+
+Similar normalization for GitHub profiles:
+
+```typescript
+async validate(
+  _accessToken: string,
+  _refreshToken: string,
+  profile: Profile,
+  done: (err: any, user?: any) => void,
+): Promise<void> {
+  try {
+    const { id, displayName, username, emails, photos } = profile;
+    
+    // GitHub-specific email handling (primary email)
+    const email = emails?.find((e: any) => e.primary)?.value ?? 
+                  emails?.[0]?.value ?? '';
+    
+    const oauthProfile = createOAuthProfile(
+      OAuthProvider.GITHUB,
+      String(id),
+      email,
+      displayName ?? username ?? 'GitHub User',
+      photos?.[0]?.value,
+    );
+
+    const jwt = await this.authService.findOrCreateOAuthUser(oauthProfile);
+    done(null, { accessToken: jwt });
+  } catch (err) {
+    done(err instanceof Error ? err : new BadRequestException(...));
+  }
+}
+```
+
+## Testing
+
+Comprehensive tests cover:
+
+- Provider enum values
+- Provider type guards
+- Profile validation (valid and invalid cases)
+- Optional field handling
+- Error scenarios
+- Factory function creation
+- Provider configuration
+
+### Running Tests
+
+```bash
+npm run test -- src/auth/types/oauth-profile.types.spec.ts
+```
+
+### Test Coverage
+
+- Valid profiles with all fields
+- Valid profiles without optional fields
+- Invalid provider validation
+- Missing required fields
+- Invalid field types
+- Null/undefined handling
+- Factory function validation
+- Provider configuration
+
+## Migration Guide
+
+### Before
+
+```typescript
+// Loosely typed, no validation
+const jwt = await this.authService.findOrCreateOAuthUser({
+  provider: 'google',
+  providerId: id,
+  email,
+  name,
+  avatarUrl,
+});
+```
+
+### After
+
+```typescript
+// Strictly typed, validated
+const oauthProfile = createOAuthProfile(
+  OAuthProvider.GOOGLE,
+  id,
+  email,
+  name ?? 'Google User',
+  avatarUrl,
+);
+const jwt = await this.authService.findOrCreateOAuthUser(oauthProfile);
+```
+
+## Adding New OAuth Providers
+
+To add a new provider (e.g., GitHub, LinkedIn):
+
+### 1. Update the Enum
+
+```typescript
+export enum OAuthProvider {
+  GOOGLE = 'google',
+  GITHUB = 'github',
+  NEW_PROVIDER = 'new-provider', // Add new provider
+}
+```
+
+### 2. Add Configuration
+
+```typescript
+export const OAUTH_PROVIDER_CONFIG = {
+  // ... existing
+  new_provider: {
+    displayName: 'New Provider',
+    scope: ['email', 'profile'],
+  },
+};
+```
+
+### 3. Create Strategy
+
+Import and use the types:
+
+```typescript
+import { createOAuthProfile, OAuthProvider } from '../types/oauth-profile.types';
+
+export class NewProviderStrategy extends PassportStrategy(...) {
+  async validate(...) {
+    const oauthProfile = createOAuthProfile(
+      OAuthProvider.NEW_PROVIDER,
+      providerId,
+      email,
+      name,
+      avatarUrl,
+    );
+    return this.authService.findOrCreateOAuthUser(oauthProfile);
+  }
+}
+```
+
+### 4. Add Tests
+
+Update `oauth-profile.types.spec.ts` to test the new provider.
+
+## Benefits
+
+1. **Type Safety**: Full TypeScript compilation-time validation
+2. **Runtime Safety**: Profile validation at service boundary
+3. **Consistency**: All providers normalized to same contract
+4. **Maintainability**: Clear interface for strategy-service communication
+5. **Extensibility**: Easy to add new providers
+6. **Documentation**: Self-documenting through types
+7. **Error Handling**: Descriptive validation error messages
+
+## Files Modified
+
+- `src/auth/types/oauth-profile.types.ts` - New type definitions and validators
+- `src/auth/types/oauth-profile.types.spec.ts` - Comprehensive test suite
+- `src/auth/auth.service.ts` - Imported and uses typed profile
+- `src/auth/strategies/google.strategy.ts` - Updated to use typed profile
+- `src/auth/strategies/github.strategy.ts` - Updated to use typed profile
+
+## Related Documentation
+
+- [OAuth 2.0 Specification](https://tools.ietf.org/html/rfc6749)
+- [Passport.js Documentation](http://www.passportjs.org/)
+- [TypeScript Type Guards](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates)

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,12 +5,13 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 import { JwtService } from '@nestjs/jwt';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { crypto } from 'crypto'; // Built-in Node module
 import { generateSecret, generateURI, verify } from 'otplib';
 import * as qrcode from 'qrcode';
 import { PrismaService } from '../prisma.service';
+import { OAuthProfile, validateOAuthProfile } from './types/oauth-profile.types';
 import {
   UserPasswordChangedEvent,
   AuthPasswordResetRequestedEvent,
@@ -303,8 +304,24 @@ export class AuthService {
   /**
    * Find an existing user by email (or provider ID) and return a JWT,
    * or create a new user record if none exists, then return a JWT.
+   *
+   * Enforces strict typing via OAuthProfile contract.
+   * Validates profile data before processing.
+   *
+   * @param profile - The OAuth profile (must conform to OAuthProfile contract)
+   * @returns JWT token for the user
+   * @throws BadRequestException if profile validation fails
    */
   async findOrCreateOAuthUser(profile: OAuthProfile): Promise<string> {
+    // Validate profile against contract
+    try {
+      validateOAuthProfile(profile);
+    } catch (error) {
+      throw new BadRequestException(
+        `Invalid OAuth profile: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+
     const { provider, providerId, email, name, avatarUrl } = profile;
 
     // 1. Try to find by email first (link social login to existing account)

--- a/src/auth/strategies/github.strategy.ts
+++ b/src/auth/strategies/github.strategy.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy } from 'passport-github2';
+import { Strategy, Profile } from 'passport-github2';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from '../auth.service';
+import { createOAuthProfile, OAuthProvider } from '../types/oauth-profile.types';
 
 @Injectable()
 export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
@@ -22,29 +23,39 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
   async validate(
     _accessToken: string,
     _refreshToken: string,
-    profile: any,
+    profile: Profile,
     done: (err: any, user?: any) => void,
   ): Promise<void> {
-    const { id, displayName, username, emails, photos } = profile;
-
-    // GitHub may return emails as an array; pick the primary one
-    const email: string =
-      emails?.find((e: any) => e.primary)?.value ?? emails?.[0]?.value ?? '';
-
-    const name: string = displayName ?? username ?? '';
-    const avatarUrl: string = photos?.[0]?.value ?? '';
-
     try {
-      const jwt = await this.authService.findOrCreateOAuthUser({
-        provider: 'github',
-        providerId: String(id),
+      // Extract profile data from GitHub's response
+      const { id, displayName, username, emails, photos } = profile;
+
+      // GitHub may return emails as an array; pick the primary one
+      const email: string =
+        emails?.find((e: any) => e.primary)?.value ?? emails?.[0]?.value ?? '';
+
+      // Normalize name - prefer displayName, fall back to username
+      const name: string = displayName ?? username ?? 'GitHub User';
+      const avatarUrl: string = photos?.[0]?.value;
+
+      // Create a strictly typed OAuth profile contract
+      const oauthProfile = createOAuthProfile(
+        OAuthProvider.GITHUB,
+        String(id),
         email,
         name,
         avatarUrl,
-      });
+      );
+
+      // Pass to auth service for user creation/lookup
+      const jwt = await this.authService.findOrCreateOAuthUser(oauthProfile);
       done(null, { accessToken: jwt });
     } catch (err) {
-      done(err as Error);
+      done(
+        err instanceof Error
+          ? err
+          : new BadRequestException('GitHub OAuth validation failed'),
+      );
     }
   }
 }

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy, VerifyCallback } from 'passport-google-oauth20';
+import { Strategy, VerifyCallback, Profile } from 'passport-google-oauth20';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from '../auth.service';
+import { createOAuthProfile, OAuthProvider } from '../types/oauth-profile.types';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -21,25 +22,36 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   async validate(
     _accessToken: string,
     _refreshToken: string,
-    profile: any,
+    profile: Profile,
     done: VerifyCallback,
   ): Promise<void> {
-    const { id, displayName, emails, photos } = profile;
-    const email: string = emails?.[0]?.value ?? '';
-    const name: string = displayName ?? '';
-    const avatarUrl: string = photos?.[0]?.value ?? '';
-
     try {
-      const jwt = await this.authService.findOrCreateOAuthUser({
-        provider: 'google',
-        providerId: id,
+      // Extract profile data from Google's response
+      const { id, displayName, emails, photos } = profile;
+
+      // Normalize email and name
+      const email: string = emails?.[0]?.value ?? '';
+      const name: string = displayName ?? 'Google User';
+      const avatarUrl: string = photos?.[0]?.value;
+
+      // Create a strictly typed OAuth profile contract
+      const oauthProfile = createOAuthProfile(
+        OAuthProvider.GOOGLE,
+        id,
         email,
         name,
         avatarUrl,
-      });
+      );
+
+      // Pass to auth service for user creation/lookup
+      const jwt = await this.authService.findOrCreateOAuthUser(oauthProfile);
       done(null, { accessToken: jwt });
     } catch (err) {
-      done(err as Error, false);
+      done(
+        err instanceof Error
+          ? err
+          : new BadRequestException('Google OAuth validation failed'),
+      );
     }
   }
 }

--- a/src/auth/types/oauth-profile.types.spec.ts
+++ b/src/auth/types/oauth-profile.types.spec.ts
@@ -1,0 +1,307 @@
+import {
+  OAuthProvider,
+  isSupportedOAuthProvider,
+  isValidOAuthProfile,
+  validateOAuthProfile,
+  createOAuthProfile,
+  OAUTH_PROVIDER_CONFIG,
+} from './oauth-profile.types';
+
+describe('OAuth Profile Types and Validation', () => {
+  describe('OAuthProvider enum', () => {
+    it('should have GOOGLE provider', () => {
+      expect(OAuthProvider.GOOGLE).toBe('google');
+    });
+
+    it('should have GITHUB provider', () => {
+      expect(OAuthProvider.GITHUB).toBe('github');
+    });
+  });
+
+  describe('isSupportedOAuthProvider', () => {
+    it('should return true for supported providers', () => {
+      expect(isSupportedOAuthProvider('google')).toBe(true);
+      expect(isSupportedOAuthProvider('github')).toBe(true);
+    });
+
+    it('should return false for unsupported providers', () => {
+      expect(isSupportedOAuthProvider('facebook')).toBe(false);
+      expect(isSupportedOAuthProvider('twitter')).toBe(false);
+      expect(isSupportedOAuthProvider('')).toBe(false);
+    });
+
+    it('should return false for non-string values', () => {
+      expect(isSupportedOAuthProvider(null as any)).toBe(false);
+      expect(isSupportedOAuthProvider(undefined as any)).toBe(false);
+      expect(isSupportedOAuthProvider({} as any)).toBe(false);
+    });
+  });
+
+  describe('isValidOAuthProfile', () => {
+    it('should validate a complete valid profile', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+        avatarUrl: 'https://example.com/avatar.jpg',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(true);
+    });
+
+    it('should validate a profile without optional avatarUrl', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(true);
+    });
+
+    it('should reject profile with invalid provider', () => {
+      const profile = {
+        provider: 'facebook',
+        providerId: 'fb-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with missing provider', () => {
+      const profile = {
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with empty providerId', () => {
+      const profile = {
+        provider: 'google',
+        providerId: '',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with missing providerId', () => {
+      const profile = {
+        provider: 'google',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with missing email', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with non-string email', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 123,
+        name: 'John Doe',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with missing name', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with empty name', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: '',
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with non-string name', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 123,
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject profile with invalid avatarUrl type', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+        avatarUrl: 123,
+      };
+      expect(isValidOAuthProfile(profile)).toBe(false);
+    });
+
+    it('should reject null profile', () => {
+      expect(isValidOAuthProfile(null)).toBe(false);
+    });
+
+    it('should reject undefined profile', () => {
+      expect(isValidOAuthProfile(undefined)).toBe(false);
+    });
+
+    it('should reject non-object profile', () => {
+      expect(isValidOAuthProfile('not an object')).toBe(false);
+      expect(isValidOAuthProfile(123)).toBe(false);
+    });
+  });
+
+  describe('validateOAuthProfile', () => {
+    it('should not throw for valid profile', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(() => validateOAuthProfile(profile)).not.toThrow();
+    });
+
+    it('should throw for invalid provider', () => {
+      const profile = {
+        provider: 'facebook',
+        providerId: 'fb-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(() => validateOAuthProfile(profile)).toThrow('Invalid OAuth profile');
+    });
+
+    it('should throw for missing name', () => {
+      const profile = {
+        provider: 'google',
+        providerId: 'google-123',
+        email: 'user@example.com',
+      };
+      expect(() => validateOAuthProfile(profile)).toThrow('Invalid OAuth profile');
+    });
+
+    it('should throw for empty providerId', () => {
+      const profile = {
+        provider: 'google',
+        providerId: '',
+        email: 'user@example.com',
+        name: 'John Doe',
+      };
+      expect(() => validateOAuthProfile(profile)).toThrow('Invalid OAuth profile');
+    });
+  });
+
+  describe('createOAuthProfile', () => {
+    it('should create a valid Google profile', () => {
+      const profile = createOAuthProfile(
+        OAuthProvider.GOOGLE,
+        'google-123',
+        'user@example.com',
+        'John Doe',
+        'https://example.com/avatar.jpg',
+      );
+
+      expect(profile).toEqual({
+        provider: OAuthProvider.GOOGLE,
+        providerId: 'google-123',
+        email: 'user@example.com',
+        name: 'John Doe',
+        avatarUrl: 'https://example.com/avatar.jpg',
+      });
+    });
+
+    it('should create a valid GitHub profile without avatar', () => {
+      const profile = createOAuthProfile(
+        OAuthProvider.GITHUB,
+        'github-456',
+        'dev@example.com',
+        'Jane Dev',
+      );
+
+      expect(profile).toEqual({
+        provider: OAuthProvider.GITHUB,
+        providerId: 'github-456',
+        email: 'dev@example.com',
+        name: 'Jane Dev',
+      });
+    });
+
+    it('should throw when creating with invalid provider', () => {
+      expect(() =>
+        createOAuthProfile(
+          'facebook' as any,
+          'fb-123',
+          'user@example.com',
+          'John Doe',
+        ),
+      ).toThrow();
+    });
+
+    it('should throw when creating with empty providerId', () => {
+      expect(() =>
+        createOAuthProfile(
+          OAuthProvider.GOOGLE,
+          '',
+          'user@example.com',
+          'John Doe',
+        ),
+      ).toThrow();
+    });
+
+    it('should throw when creating with empty name', () => {
+      expect(() =>
+        createOAuthProfile(
+          OAuthProvider.GOOGLE,
+          'google-123',
+          'user@example.com',
+          '',
+        ),
+      ).toThrow();
+    });
+  });
+
+  describe('OAUTH_PROVIDER_CONFIG', () => {
+    it('should have configuration for Google', () => {
+      const config = OAUTH_PROVIDER_CONFIG[OAuthProvider.GOOGLE];
+      expect(config.displayName).toBe('Google');
+      expect(config.scope).toContain('email');
+      expect(config.scope).toContain('profile');
+    });
+
+    it('should have configuration for GitHub', () => {
+      const config = OAUTH_PROVIDER_CONFIG[OAuthProvider.GITHUB];
+      expect(config.displayName).toBe('GitHub');
+      expect(config.scope).toContain('user:email');
+    });
+
+    it('should have all supported providers configured', () => {
+      const providers = Object.values(OAuthProvider);
+      providers.forEach((provider) => {
+        expect(OAUTH_PROVIDER_CONFIG[provider]).toBeDefined();
+        expect(OAUTH_PROVIDER_CONFIG[provider].displayName).toBeTruthy();
+        expect(OAUTH_PROVIDER_CONFIG[provider].scope).toBeTruthy();
+        expect(Array.isArray(OAUTH_PROVIDER_CONFIG[provider].scope)).toBe(true);
+      });
+    });
+  });
+});

--- a/src/auth/types/oauth-profile.types.ts
+++ b/src/auth/types/oauth-profile.types.ts
@@ -1,0 +1,163 @@
+/**
+ * OAuth Profile Types and Contracts
+ *
+ * This module defines strict typing for OAuth provider profiles
+ * to ensure consistent handling of third-party authentication data.
+ */
+
+/**
+ * Supported OAuth providers in the application
+ */
+export enum OAuthProvider {
+  GOOGLE = 'google',
+  GITHUB = 'github',
+}
+
+/**
+ * Validates if a string is a supported OAuth provider
+ */
+export function isSupportedOAuthProvider(
+  provider: string,
+): provider is OAuthProvider {
+  return Object.values(OAuthProvider).includes(provider as OAuthProvider);
+}
+
+/**
+ * Core OAuth Profile Contract
+ *
+ * This interface defines the strict contract for OAuth user profiles.
+ * All OAuth strategies must normalize their provider-specific data
+ * into this contract before calling findOrCreateOAuthUser.
+ *
+ * Fields:
+ * - provider: The OAuth provider identifier (google, github, etc.)
+ * - providerId: The unique user ID from the OAuth provider
+ * - email: The user's email address (may be empty for some providers)
+ * - name: The user's display name
+ * - avatarUrl: The user's profile picture URL (optional)
+ */
+export interface OAuthProfile {
+  provider: OAuthProvider;
+  providerId: string;
+  email: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+/**
+ * Validates an OAuth profile object against the contract
+ *
+ * @param profile - The profile object to validate
+ * @returns true if the profile is valid, false otherwise
+ */
+export function isValidOAuthProfile(profile: any): profile is OAuthProfile {
+  if (!profile || typeof profile !== 'object') {
+    return false;
+  }
+
+  // Validate required fields
+  if (!isString(profile.provider) || !isSupportedOAuthProvider(profile.provider)) {
+    return false;
+  }
+
+  if (!isString(profile.providerId) || profile.providerId.length === 0) {
+    return false;
+  }
+
+  if (!isString(profile.email)) {
+    return false;
+  }
+
+  if (!isString(profile.name) || profile.name.length === 0) {
+    return false;
+  }
+
+  // Validate optional fields
+  if (profile.avatarUrl !== undefined && !isString(profile.avatarUrl)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validates an OAuth profile and throws a descriptive error if invalid
+ *
+ * @param profile - The profile object to validate
+ * @throws Error with details about validation failure
+ */
+export function validateOAuthProfile(profile: any): asserts profile is OAuthProfile {
+  if (!isValidOAuthProfile(profile)) {
+    throw new Error(
+      `Invalid OAuth profile: ${JSON.stringify({
+        hasProvider: 'provider' in profile,
+        hasProviderId: 'providerId' in profile,
+        hasEmail: 'email' in profile,
+        hasName: 'name' in profile,
+        hasAvatarUrl: 'avatarUrl' in profile,
+      })}`,
+    );
+  }
+}
+
+/**
+ * Creates a typed OAuth profile from raw OAuth provider data
+ *
+ * This function ensures type safety when constructing profiles
+ * from OAuth provider responses.
+ *
+ * @param provider - The OAuth provider
+ * @param providerId - The user's ID from the provider
+ * @param email - The user's email
+ * @param name - The user's display name
+ * @param avatarUrl - Optional user's profile picture URL
+ * @returns A valid OAuthProfile
+ * @throws Error if validation fails
+ */
+export function createOAuthProfile(
+  provider: OAuthProvider,
+  providerId: string,
+  email: string,
+  name: string,
+  avatarUrl?: string,
+): OAuthProfile {
+  const profile: OAuthProfile = {
+    provider,
+    providerId,
+    email,
+    name,
+    ...(avatarUrl && { avatarUrl }),
+  };
+
+  validateOAuthProfile(profile);
+  return profile;
+}
+
+/**
+ * Utility type guard for string validation
+ */
+function isString(value: any): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * OAuth Provider Configuration
+ *
+ * Metadata about each supported OAuth provider
+ */
+export const OAUTH_PROVIDER_CONFIG: Record<
+  OAuthProvider,
+  {
+    displayName: string;
+    scope: string[];
+  }
+> = {
+  [OAuthProvider.GOOGLE]: {
+    displayName: 'Google',
+    scope: ['email', 'profile'],
+  },
+  [OAuthProvider.GITHUB]: {
+    displayName: 'GitHub',
+    scope: ['user:email'],
+  },
+};


### PR DESCRIPTION
- Closes #312 

Introduce strict typing and validation for OAuth user profiles to ensure consistent handling of third-party authentication data.

Changes:
- Create OAuthProfile interface enforcing required fields (provider, providerId, email, name, avatarUrl)
- Add OAuthProvider enum for supported providers (Google, GitHub)
- Implement validation functions: isValidOAuthProfile, validateOAuthProfile, createOAuthProfile
- Add OAUTH_PROVIDER_CONFIG for provider metadata and scopes
- Update auth.service.ts findOrCreateOAuthUser to validate profiles
- Update Google strategy to use typed profile creation
- Update GitHub strategy to use typed profile creation
- Add comprehensive test suite (32 tests) covering all validation scenarios

Benefits:
- Compile-time type safety for OAuth profiles
- Runtime validation with descriptive errors
- Clear contract between strategies and auth service
- Self-documenting through TypeScript types
- Easy to extend with new OAuth providers
- Prevents malformed profiles from reaching user creation

- Closes #313