### PR TITLE
feat: #372 Add standardized GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug report
+description: Report a defect with clear reproduction details, impact, and validation expectations.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        Please share enough detail for the team to reproduce the issue, assess impact, and add a regression fix with confidence.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Problem summary
+      description: What is broken, and why does it matter?
+      placeholder: A concise description of the defect and the affected workflow.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How serious is the issue?
+      options:
+        - Sev 1 - blocks production or core developer workflows
+        - Sev 2 - major functionality is degraded
+        - Sev 3 - moderate issue with a workaround
+        - Sev 4 - minor issue or polish gap
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, endpoint, workflow, or document is involved?
+      placeholder: e.g. orders module, auth guards, payment webhook, README setup steps
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: What happens today?
+      placeholder: Describe the actual behavior, error, or failure mode.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+      placeholder: Describe the correct behavior or desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the shortest reliable path to reproduce the issue.
+      placeholder: |
+        1. Start the app with ...
+        2. Call POST /...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who or what is affected?
+      placeholder: User impact, operational risk, release risk, contributor friction, or business impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs, screenshots, or additional context
+      description: Paste errors, traces, request/response samples, screenshots, or links that help triage.
+      placeholder: Add any supporting context that helps narrow the problem.
+      render: shell
+
+  - type: textarea
+    id: validation_plan
+    attributes:
+      label: Validation and regression coverage
+      description: How should we verify the fix and guard against regressions?
+      placeholder: Tests to add or update, manual verification steps, monitoring checks, and any impacted docs.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I included reproduction details and impact information.
+          required: true
+        - label: I identified the affected area or module as clearly as I could.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,90 @@
+name: Feature request
+description: Propose a feature with problem framing, scope, acceptance criteria, and rollout considerations.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for net-new capabilities, meaningful enhancements, or UX improvements.
+
+        Strong requests start with the problem, not just the solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user, product, or developer problem are we solving?
+      placeholder: Describe the pain point, gap, or opportunity.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: What change do you want to see?
+      placeholder: Describe the desired feature, workflow, or API behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: value
+    attributes:
+      label: Expected value
+      description: Why is this worth doing now?
+      placeholder: Explain the benefit for users, maintainers, operations, or release confidence.
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, endpoint, workflow, or document is likely to change?
+      placeholder: e.g. recommendations, checkout flow, notification jobs, README, local infra docs
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and acceptance criteria
+      description: What is in scope, out of scope, and how do we know this is done?
+      placeholder: Define expected behavior, constraints, and concrete acceptance criteria.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies, sequencing, or affected integrations
+      description: Note related modules, migrations, external services, contracts, or other issues/PRs.
+      placeholder: Mention anything this work depends on or may impact.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other options did you evaluate?
+      placeholder: List alternatives, tradeoffs, or reasons for rejecting them.
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: How should this be tested and documented?
+      placeholder: Unit/integration/e2e coverage, manual checks, docs updates, migrations, rollout notes.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I described the problem and expected value, not only the implementation idea.
+          required: true
+        - label: I included scope, acceptance criteria, and validation expectations.
+          required: true

--- a/.github/ISSUE_TEMPLATE/refactor_request.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_request.yml
@@ -1,0 +1,92 @@
+name: Refactor request
+description: Propose a structural improvement that preserves behavior while improving maintainability, clarity, or safety.
+title: "[Refactor]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for behavior-preserving structural changes.
+
+        A good refactor issue explains the current pain, the intended boundaries, and how we will prove nothing regressed.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Current pain or maintenance problem
+      description: What makes the current implementation hard to work with?
+      placeholder: Describe the source of complexity, brittleness, duplication, or confusion.
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, directory, or workflow should be refactored?
+      placeholder: e.g. auth service, order orchestration, shared DTOs, queue processors
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: Refactor goals
+      description: What should improve after this refactor?
+      placeholder: "Examples: clearer boundaries, reduced duplication, simpler tests, safer extension points."
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals or out-of-scope items
+      description: What should stay unchanged?
+      placeholder: List behaviors, interfaces, or adjacent areas that should not be altered.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_approach
+    attributes:
+      label: Proposed approach
+      description: Describe the structural change at a high level.
+      placeholder: Modules to split, abstractions to introduce, contracts to preserve, or files to align.
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and compatibility concerns
+      description: What could break if we get this wrong?
+      placeholder: Call out behavior changes to avoid, migration risks, or tricky integration points.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation and regression plan
+      description: How do we prove the refactor is safe?
+      placeholder: Existing tests to preserve, new coverage to add, manual checks, docs that may need updates.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies or sequencing notes
+      description: Mention related issues, prerequisite cleanup, or follow-up slices.
+      placeholder: Link any related work or required ordering.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I described the current pain and the target improvement.
+          required: true
+        - label: I included non-goals so the behavior-preserving boundary is clear.
+          required: true
+        - label: I included a validation plan to catch regressions.
+          required: true

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,0 +1,92 @@
+name: Tech debt
+description: Track engineering debt that reduces velocity, increases risk, or makes future work harder.
+title: "[Tech Debt]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for debt that should be tracked, prioritized, and eventually retired.
+
+        The goal is to make the cost of delay visible and actionable.
+
+  - type: textarea
+    id: debt_summary
+    attributes:
+      label: Debt summary
+      description: What debt are we carrying?
+      placeholder: Describe the shortcut, outdated pattern, fragile implementation, or missing safeguard.
+    validations:
+      required: true
+
+  - type: textarea
+    id: origin
+    attributes:
+      label: Origin or context
+      description: Why does this debt exist?
+      placeholder: Historical reason, temporary tradeoff, missing dependency alignment, blocked refactor, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, directory, workflow, or dependency is affected?
+      placeholder: e.g. payment retries, Redis caching, auth DTOs, package dependency versions
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Cost and impact
+      description: How does this debt slow us down or increase risk?
+      placeholder: Contributor friction, bug risk, release risk, operational load, test brittleness, performance cost.
+    validations:
+      required: true
+
+  - type: textarea
+    id: remediation
+    attributes:
+      label: Proposed remediation
+      description: What should we do to reduce or remove the debt?
+      placeholder: Cleanup steps, dependency alignment, guardrails, follow-up refactors, docs updates.
+    validations:
+      required: true
+
+  - type: textarea
+    id: if_deferred
+    attributes:
+      label: If deferred
+      description: What happens if we leave this in place for another release cycle?
+      placeholder: Describe the likely cost of delay, risks, or temporary workaround.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: How should this debt payoff be verified?
+      placeholder: Tests to add or preserve, manual checks, metrics to monitor, docs or migration notes to update.
+    validations:
+      required: true
+
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Dependencies or blockers
+      description: Note related issues, upstream changes, migrations, or modules that need to move first.
+      placeholder: Mention known blockers or linked work.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I described the debt and its impact on the team or product.
+          required: true
+        - label: I included a remediation direction rather than only stating the problem.
+          required: true
+        - label: I included validation expectations and any known blockers.
+          required: true

--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ $ npm run start:prod
 
 We require PRs to follow a quality checklist (tests, migration notes, docs). See [docs/pr-checklist.md](docs/pr-checklist.md) for details and use the repository PR template when opening a PR.
 
+## Issue Reporting
+
+We use standardized GitHub issue templates to keep triage fast and consistent. Please choose the template that matches your request:
+
+- Bug report: for defects, regressions, and unexpected behavior. Include reproduction steps, impact, and a validation plan.
+- Feature request: for new capabilities or meaningful enhancements. Include the problem, expected value, acceptance criteria, and testing/docs expectations.
+- Refactor request: for behavior-preserving structural improvements. Include current pain, goals, non-goals, risks, and regression coverage expectations.
+- Tech debt: for shortcuts, brittle patterns, dependency alignment, or missing safeguards that reduce engineering velocity or increase risk over time.
+
+Blank issues are disabled so requests consistently include the details reviewers need to triage, scope, and ship changes safely.
+
 
 ---
 


### PR DESCRIPTION
Implemented #372.

Added standardized GitHub Issue Forms for bugs, features, refactors, and tech debt in:

bug_report.yml (line 1)
feature_request.yml (line 1)
refactor_request.yml (line 1)
tech_debt.yml (line 1)
I also added issue template config (line 1) to disable blank issues, and updated the contributor docs in README.md (line 99) so the new reporting flow is documented alongside the existing PR checklist.

Validation is done for the affected area: all new YAML files parse successfully with PyYAML, and git diff --check is clean. I didn’t run application tests because this change only touches GitHub metadata and documentation, not runtime code.

closes #372 