### PR TITLE
Feat/introduce architecture decision records

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug report
+description: Report a defect with clear reproduction details, impact, and validation expectations.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        Please share enough detail for the team to reproduce the issue, assess impact, and add a regression fix with confidence.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Problem summary
+      description: What is broken, and why does it matter?
+      placeholder: A concise description of the defect and the affected workflow.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How serious is the issue?
+      options:
+        - Sev 1 - blocks production or core developer workflows
+        - Sev 2 - major functionality is degraded
+        - Sev 3 - moderate issue with a workaround
+        - Sev 4 - minor issue or polish gap
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, endpoint, workflow, or document is involved?
+      placeholder: e.g. orders module, auth guards, payment webhook, README setup steps
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: What happens today?
+      placeholder: Describe the actual behavior, error, or failure mode.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+      placeholder: Describe the correct behavior or desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the shortest reliable path to reproduce the issue.
+      placeholder: |
+        1. Start the app with ...
+        2. Call POST /...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who or what is affected?
+      placeholder: User impact, operational risk, release risk, contributor friction, or business impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs, screenshots, or additional context
+      description: Paste errors, traces, request/response samples, screenshots, or links that help triage.
+      placeholder: Add any supporting context that helps narrow the problem.
+      render: shell
+
+  - type: textarea
+    id: validation_plan
+    attributes:
+      label: Validation and regression coverage
+      description: How should we verify the fix and guard against regressions?
+      placeholder: Tests to add or update, manual verification steps, monitoring checks, and any impacted docs.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I included reproduction details and impact information.
+          required: true
+        - label: I identified the affected area or module as clearly as I could.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,90 @@
+name: Feature request
+description: Propose a feature with problem framing, scope, acceptance criteria, and rollout considerations.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for net-new capabilities, meaningful enhancements, or UX improvements.
+
+        Strong requests start with the problem, not just the solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user, product, or developer problem are we solving?
+      placeholder: Describe the pain point, gap, or opportunity.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: What change do you want to see?
+      placeholder: Describe the desired feature, workflow, or API behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: value
+    attributes:
+      label: Expected value
+      description: Why is this worth doing now?
+      placeholder: Explain the benefit for users, maintainers, operations, or release confidence.
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, endpoint, workflow, or document is likely to change?
+      placeholder: e.g. recommendations, checkout flow, notification jobs, README, local infra docs
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and acceptance criteria
+      description: What is in scope, out of scope, and how do we know this is done?
+      placeholder: Define expected behavior, constraints, and concrete acceptance criteria.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies, sequencing, or affected integrations
+      description: Note related modules, migrations, external services, contracts, or other issues/PRs.
+      placeholder: Mention anything this work depends on or may impact.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other options did you evaluate?
+      placeholder: List alternatives, tradeoffs, or reasons for rejecting them.
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: How should this be tested and documented?
+      placeholder: Unit/integration/e2e coverage, manual checks, docs updates, migrations, rollout notes.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I described the problem and expected value, not only the implementation idea.
+          required: true
+        - label: I included scope, acceptance criteria, and validation expectations.
+          required: true

--- a/.github/ISSUE_TEMPLATE/refactor_request.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_request.yml
@@ -1,0 +1,92 @@
+name: Refactor request
+description: Propose a structural improvement that preserves behavior while improving maintainability, clarity, or safety.
+title: "[Refactor]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for behavior-preserving structural changes.
+
+        A good refactor issue explains the current pain, the intended boundaries, and how we will prove nothing regressed.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Current pain or maintenance problem
+      description: What makes the current implementation hard to work with?
+      placeholder: Describe the source of complexity, brittleness, duplication, or confusion.
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, directory, or workflow should be refactored?
+      placeholder: e.g. auth service, order orchestration, shared DTOs, queue processors
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: Refactor goals
+      description: What should improve after this refactor?
+      placeholder: "Examples: clearer boundaries, reduced duplication, simpler tests, safer extension points."
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals or out-of-scope items
+      description: What should stay unchanged?
+      placeholder: List behaviors, interfaces, or adjacent areas that should not be altered.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_approach
+    attributes:
+      label: Proposed approach
+      description: Describe the structural change at a high level.
+      placeholder: Modules to split, abstractions to introduce, contracts to preserve, or files to align.
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and compatibility concerns
+      description: What could break if we get this wrong?
+      placeholder: Call out behavior changes to avoid, migration risks, or tricky integration points.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation and regression plan
+      description: How do we prove the refactor is safe?
+      placeholder: Existing tests to preserve, new coverage to add, manual checks, docs that may need updates.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies or sequencing notes
+      description: Mention related issues, prerequisite cleanup, or follow-up slices.
+      placeholder: Link any related work or required ordering.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I described the current pain and the target improvement.
+          required: true
+        - label: I included non-goals so the behavior-preserving boundary is clear.
+          required: true
+        - label: I included a validation plan to catch regressions.
+          required: true

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,0 +1,92 @@
+name: Tech debt
+description: Track engineering debt that reduces velocity, increases risk, or makes future work harder.
+title: "[Tech Debt]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for debt that should be tracked, prioritized, and eventually retired.
+
+        The goal is to make the cost of delay visible and actionable.
+
+  - type: textarea
+    id: debt_summary
+    attributes:
+      label: Debt summary
+      description: What debt are we carrying?
+      placeholder: Describe the shortcut, outdated pattern, fragile implementation, or missing safeguard.
+    validations:
+      required: true
+
+  - type: textarea
+    id: origin
+    attributes:
+      label: Origin or context
+      description: Why does this debt exist?
+      placeholder: Historical reason, temporary tradeoff, missing dependency alignment, blocked refactor, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: affected_area
+    attributes:
+      label: Affected area or module
+      description: Which service, module, directory, workflow, or dependency is affected?
+      placeholder: e.g. payment retries, Redis caching, auth DTOs, package dependency versions
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Cost and impact
+      description: How does this debt slow us down or increase risk?
+      placeholder: Contributor friction, bug risk, release risk, operational load, test brittleness, performance cost.
+    validations:
+      required: true
+
+  - type: textarea
+    id: remediation
+    attributes:
+      label: Proposed remediation
+      description: What should we do to reduce or remove the debt?
+      placeholder: Cleanup steps, dependency alignment, guardrails, follow-up refactors, docs updates.
+    validations:
+      required: true
+
+  - type: textarea
+    id: if_deferred
+    attributes:
+      label: If deferred
+      description: What happens if we leave this in place for another release cycle?
+      placeholder: Describe the likely cost of delay, risks, or temporary workaround.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: How should this debt payoff be verified?
+      placeholder: Tests to add or preserve, manual checks, metrics to monitor, docs or migration notes to update.
+    validations:
+      required: true
+
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Dependencies or blockers
+      description: Note related issues, upstream changes, migrations, or modules that need to move first.
+      placeholder: Mention known blockers or linked work.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I described the debt and its impact on the team or product.
+          required: true
+        - label: I included a remediation direction rather than only stating the problem.
+          required: true
+        - label: I included validation expectations and any known blockers.
+          required: true

--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ $ npm run start:prod
 
 We require PRs to follow a quality checklist (tests, migration notes, docs). See [docs/pr-checklist.md](docs/pr-checklist.md) for details and use the repository PR template when opening a PR.
 
+## Issue Reporting
+
+We use standardized GitHub issue templates to keep triage fast and consistent. Please choose the template that matches your request:
+
+- Bug report: for defects, regressions, and unexpected behavior. Include reproduction steps, impact, and a validation plan.
+- Feature request: for new capabilities or meaningful enhancements. Include the problem, expected value, acceptance criteria, and testing/docs expectations.
+- Refactor request: for behavior-preserving structural improvements. Include current pain, goals, non-goals, risks, and regression coverage expectations.
+- Tech debt: for shortcuts, brittle patterns, dependency alignment, or missing safeguards that reduce engineering velocity or increase risk over time.
+
+Blank issues are disabled so requests consistently include the details reviewers need to triage, scope, and ship changes safely.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ $ npm run start:prod
 
 We require PRs to follow a quality checklist (tests, migration notes, docs). See [docs/pr-checklist.md](docs/pr-checklist.md) for details and use the repository PR template when opening a PR.
 
+## Architecture Decisions
+
+We track major architectural choices in [docs/adr/README.md](docs/adr/README.md). If a change introduces or materially changes module boundaries, async data flow, infrastructure roles, or long-lived domain workflows, update the relevant ADR or add a new one in the same PR.
+
 ## Issue Reporting
 
 We use standardized GitHub issue templates to keep triage fast and consistent. Please choose the template that matches your request:
@@ -145,4 +149,4 @@ To get started, please browse our active GitHub Issues (or Drips tasks). When yo
 
 ## 📜 License & Support
 
-MarketX is [MIT licensed](LICENSE). If you encounter any issues spinning up the environment, please drop an Issue on GitHub. Let's build something incredible together! 🚀
+MarketX is MIT licensed. If you encounter any issues spinning up the environment, please drop an Issue on GitHub. Let's build something incredible together! 🚀

--- a/docs/adr/0001-modular-monolith-with-domain-modules.md
+++ b/docs/adr/0001-modular-monolith-with-domain-modules.md
@@ -1,0 +1,47 @@
+# ADR 0001: Use a modular monolith with explicit NestJS domain modules
+
+- Status: Accepted
+- Date: 2026-04-24
+- Deciders: MarketX maintainers
+- Technical Story: #371 Introduce architecture decision records
+
+## Context
+
+MarketX already operates as a single NestJS application that imports a large set of domain and infrastructure modules through `AppModule`. Contributors need a stable mental model for where new behavior belongs, how shared capabilities should be exposed, and when a feature should stay in-process versus becoming a separate service.
+
+Without a written decision, the repository invites accidental coupling in `common/`, one-off cross-module shortcuts, or premature microservice splits that would make local development and release coordination harder.
+
+## Decision
+
+MarketX will remain a modular monolith by default.
+
+- Domain capabilities should live in explicit NestJS feature modules such as `orders`, `payments`, `notifications`, `refunds`, `products`, and `auth`.
+- Cross-cutting platform capabilities should live in shared infrastructure modules such as `common`, `health`, `messaging`, `job-processing`, `redis-caching`, and `backup`.
+- New features should extend an existing module when they belong to that bounded context; otherwise they should introduce a new module with clear ownership instead of spreading behavior across unrelated folders.
+- Cross-module behavior should flow through explicit service interfaces, events, queues, or shared contracts rather than hidden imports and duplicated logic.
+- We should not split modules into separately deployed services unless there is a concrete operational requirement such as isolation, scaling pressure, ownership separation, or external integration boundaries that the modular monolith can no longer handle cleanly.
+
+## Consequences
+
+### Positive
+
+- Local development stays simple because contributors can run one API process against the local infrastructure profile.
+- Shared transactions, validation rules, and typed contracts remain easier to coordinate across tightly related marketplace domains.
+- Module ownership is easier to reason about when new code starts from a clear feature boundary.
+
+### Negative
+
+- The application can accumulate coupling if maintainers allow too much logic to drift into shared modules.
+- Build, startup, and review scope can grow as the monolith grows.
+- Strong boundaries still require discipline because deployment boundaries will not enforce them for us.
+
+## Validation and follow-up
+
+- Keep `AppModule` imports and module-level docs aligned with the actual feature boundaries.
+- Prefer architectural reviews when a change adds a new top-level module or introduces a new cross-module dependency path.
+- If a future change proposes extracting a service, capture that move in a successor ADR instead of making the boundary change implicitly.
+
+## References
+
+- [`src/app.module.ts`](../../src/app.module.ts)
+- [`README.md`](../../README.md)

--- a/docs/adr/0002-async-boundaries-with-eventemitter-rabbitmq-and-bull.md
+++ b/docs/adr/0002-async-boundaries-with-eventemitter-rabbitmq-and-bull.md
@@ -1,0 +1,61 @@
+# ADR 0002: Standardize async boundaries with EventEmitter2, RabbitMQ, and Bull
+
+- Status: Accepted
+- Date: 2026-04-24
+- Deciders: MarketX maintainers
+- Technical Story: #371 Introduce architecture decision records
+
+## Context
+
+MarketX has multiple kinds of asynchronous work:
+
+- same-process side effects such as notifications and audit handlers
+- integration-facing event broadcast for downstream consumers
+- retryable or scheduled jobs such as email, image processing, and recommendation refreshes
+
+These flows were previously documented in several places, but the decision itself was implicit. Without a written standard, contributors can easily choose the wrong transport, hardcode event names, or mix synchronous business writes with retry-oriented background work.
+
+## Decision
+
+MarketX uses three async layers with distinct responsibilities:
+
+- `@nestjs/event-emitter` handles in-process domain events and same-process fan-out between modules.
+- RabbitMQ publishes durable domain-event envelopes for external consumers and future service boundaries.
+- Bull with Redis handles retryable, delayed, or long-running background jobs.
+
+Contributor rules:
+
+- Domain modules should complete the primary state transition first, then emit a typed event using the canonical `EventNames` registry.
+- In-process listeners should handle same-process side effects that belong in the current deployment unit.
+- The messaging layer should bridge canonical in-process events into RabbitMQ envelopes instead of letting each feature publish arbitrary broker payloads.
+- Background work that requires retries, scheduling, or queue visibility should go through Bull queues registered in the shared queue constants and jobs module.
+- New async flows should document which layer they use and why.
+
+## Consequences
+
+### Positive
+
+- Side effects stay decoupled from primary request handling.
+- Contributors have a consistent rule for choosing between direct calls, events, brokered messages, and queues.
+- External integrations can consume durable event envelopes without reaching into internal module implementation details.
+
+### Negative
+
+- The system carries more moving parts than a purely synchronous design.
+- Event naming and contract drift can still cause failures if constants and shared contracts are not used consistently.
+- Debugging can span controllers, listeners, queues, and broker publish paths.
+
+## Validation and follow-up
+
+- Keep event names centralized in `src/common/events.ts`.
+- Add or update tests when new queues, listeners, or event contracts are introduced.
+- Update the relevant architecture docs and this ADR whenever the async boundary rules change.
+
+## References
+
+- [`docs/EVENT_ARCHITECTURE.md`](../EVENT_ARCHITECTURE.md)
+- [`docs/EVENT_DRIVEN_ARCHITECTURE.md`](../EVENT_DRIVEN_ARCHITECTURE.md)
+- [`docs/NOTIFICATIONS_MESSAGING_BG_JOBS.md`](../NOTIFICATIONS_MESSAGING_BG_JOBS.md)
+- [`src/common/events.ts`](../../src/common/events.ts)
+- [`src/job-processing/queue.constants.ts`](../../src/job-processing/queue.constants.ts)
+- [`src/messaging/rabbitmq.module.ts`](../../src/messaging/rabbitmq.module.ts)

--- a/docs/adr/0003-postgresql-system-of-record-with-redis-and-rabbitmq.md
+++ b/docs/adr/0003-postgresql-system-of-record-with-redis-and-rabbitmq.md
@@ -1,0 +1,56 @@
+# ADR 0003: Use PostgreSQL as the system of record with Redis and RabbitMQ as supporting infrastructure
+
+- Status: Accepted
+- Date: 2026-04-24
+- Deciders: MarketX maintainers
+- Technical Story: #371 Introduce architecture decision records
+
+## Context
+
+MarketX needs dependable transactional storage for marketplace entities, fast local development, cache and queue support, and a broker for domain-event distribution. These choices appear in code and setup docs today, but contributors do not have a single place that states which systems are authoritative and which are supporting infrastructure.
+
+That distinction matters because bugs and migrations should be reasoned about differently for system-of-record data, cached data, queued work, and published events.
+
+## Decision
+
+MarketX standardizes on the following infrastructure roles:
+
+- PostgreSQL is the system of record for marketplace state and transactional workflows.
+- TypeORM is the primary ORM and entity mapping layer for persisted application data.
+- Redis is supporting infrastructure for caching, throttling support, and Bull-backed job queues.
+- RabbitMQ is supporting infrastructure for durable event broadcast and integration-facing fan-out.
+- The default contributor workflow should target the repository's local compose profile for PostgreSQL, Redis, and RabbitMQ while running the API process locally.
+
+Contributor rules:
+
+- Persist authoritative business state in PostgreSQL-backed entities first.
+- Treat Redis state as reconstructable or operational, not as the source of truth for marketplace records.
+- Treat RabbitMQ messages as delivery artifacts of domain events, not as the primary record of completed business actions.
+- Document migrations, rollbacks, and operational assumptions whenever a change alters persisted data or infrastructure expectations.
+
+## Consequences
+
+### Positive
+
+- Contributors get a clear separation between durable business data and operational infrastructure.
+- Local development mirrors the production dependency shape closely enough to catch integration issues early.
+- Data ownership becomes easier to reason about across orders, payments, notifications, and other core domains.
+
+### Negative
+
+- Operational complexity is higher than a single-database setup.
+- Developers must understand the failure modes of three backing systems instead of one.
+- Infrastructure-dependent tests may require more setup and slower feedback loops than pure unit tests.
+
+## Validation and follow-up
+
+- Keep setup docs aligned with the actual environment variables and compose profile.
+- Require migration notes when PostgreSQL-backed entities or schema assumptions change.
+- Revisit this ADR if the project adopts a second primary datastore or retires TypeORM.
+
+## References
+
+- [`src/app.module.ts`](../../src/app.module.ts)
+- [`docs/database-schema.md`](../database-schema.md)
+- [`docs/local-infra.md`](../local-infra.md)
+- [`README.md`](../../README.md)

--- a/docs/adr/0004-persist-notifications-with-retry-and-dlq.md
+++ b/docs/adr/0004-persist-notifications-with-retry-and-dlq.md
@@ -1,0 +1,49 @@
+# ADR 0004: Persist notifications first, then deliver them with retries and DLQ handling
+
+- Status: Accepted
+- Date: 2026-04-24
+- Deciders: MarketX maintainers
+- Technical Story: #371 Introduce architecture decision records
+
+## Context
+
+Notifications in MarketX span multiple channels and side effects, including in-app persistence, WebSocket delivery, email, push attempts, retries, and dead-letter handling. When notification architecture lives only in implementation docs, contributors can miss the core expectation that delivery reliability and operational visibility matter as much as feature completeness.
+
+If this remains implicit, new notification paths may bypass persistence, skip retry policies, or fail without observable recovery tooling.
+
+## Decision
+
+Notification workflows must persist notification intent before attempting channel delivery, and outbound delivery must use bounded retry and dead-letter handling when appropriate.
+
+- Notification creation should produce a durable record that can be inspected, retried, and audited.
+- Real-time and outbound delivery should be treated as side effects of that durable record, not as the sole representation of whether a notification exists.
+- Retry behavior should use structured policies with bounded backoff rather than ad hoc loops.
+- Exhausted failures should be routed to DLQ handling so operators can inspect, retry, or close them explicitly.
+- Notification lifecycle events should remain observable for monitoring and debugging.
+
+## Consequences
+
+### Positive
+
+- Users and operators have a durable record of intended notifications even when delivery fails.
+- Transient delivery failures can recover automatically without losing observability.
+- Contributors extending notification channels inherit a clear reliability model instead of inventing one per channel.
+
+### Negative
+
+- Notification code paths are more complex than direct fire-and-forget delivery.
+- Persistent records, retry logic, and DLQ state introduce additional storage and operational surfaces.
+- Contributors must think about idempotency and lifecycle events when adding new delivery behavior.
+
+## Validation and follow-up
+
+- Add tests when new channels, retry policies, or DLQ transitions are introduced.
+- Keep health, monitoring, and operational docs aligned with delivery behavior.
+- Update this ADR if the project changes the persistence-first rule or adopts a different failure-handling model.
+
+## References
+
+- [`docs/NOTIFICATIONS_MESSAGING_BG_JOBS.md`](../NOTIFICATIONS_MESSAGING_BG_JOBS.md)
+- [`src/notifications/notifications.service.ts`](../../src/notifications/notifications.service.ts)
+- [`src/notifications/retry-strategy.service.ts`](../../src/notifications/retry-strategy.service.ts)
+- [`src/notifications/dead-letter-queue.service.ts`](../../src/notifications/dead-letter-queue.service.ts)

--- a/docs/adr/0005-payment-confirmation-drives-order-progression.md
+++ b/docs/adr/0005-payment-confirmation-drives-order-progression.md
@@ -1,0 +1,49 @@
+# ADR 0005: Treat payment confirmation as the gate for order payment progression
+
+- Status: Accepted
+- Date: 2026-04-24
+- Deciders: MarketX maintainers
+- Technical Story: #371 Introduce architecture decision records
+
+## Context
+
+MarketX handles marketplace payments through explicit payment records, monitoring, verification, timeout handling, and downstream order updates. Contributors touching orders, payments, escrow, or webhooks need a stable rule for how payment state affects order state and where payment verification logic belongs.
+
+If this stays implicit, it becomes easy to collapse payment and order state together, update orders before payment verification is complete, or bypass timeout and audit behavior in one-off integrations.
+
+## Decision
+
+Payment confirmation is the gate that advances order payment progression.
+
+- Creating an order and initiating a payment are distinct steps with separate state.
+- Payments should be represented as first-class records tied to an order and tracked through pending, confirmed, failed, timeout, or refunded states.
+- Verification logic belongs in the payment flow, including stream monitoring, webhook handling, or explicit verification endpoints.
+- Orders should only move into paid payment states after the payment module confirms the payment against the expected amount, currency, and destination.
+- Timeout, failure, and refund handling should update payment state explicitly instead of inferring success from incomplete external signals.
+
+## Consequences
+
+### Positive
+
+- Payment workflows remain auditable and easier to debug than direct order-status mutation.
+- Order lifecycle logic can rely on a verified payment boundary instead of scattered integration callbacks.
+- Future escrow and reconciliation work has a cleaner foundation because payment state remains explicit.
+
+### Negative
+
+- The model is more complex than a single status flag on orders.
+- Contributors must coordinate changes across payment, order, and notification paths when payment lifecycle behavior changes.
+- Integrations must tolerate eventual consistency between payment confirmation and downstream side effects.
+
+## Validation and follow-up
+
+- Preserve regression coverage for payment verification, timeout handling, and order updates whenever these flows change.
+- Document any new payment method or escrow integration that changes the confirmation boundary.
+- Add a successor ADR if escrow release or multi-provider payment orchestration becomes the dominant architectural boundary.
+
+## References
+
+- [`docs/PAYMENT_PROCESSING.md`](../PAYMENT_PROCESSING.md)
+- [`docs/database-schema.md`](../database-schema.md)
+- [`src/payments`](../../src/payments)
+- [`src/orders`](../../src/orders)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records
+
+This directory stores Architecture Decision Records (ADRs) for MarketX.
+
+ADRs capture architectural decisions that should remain easy to find long after the related pull request, issue, or chat thread is gone. They are especially useful when a choice affects multiple modules, changes contributor workflow, or introduces constraints that future work must respect.
+
+## When to add or update an ADR
+
+Create or update an ADR when a change:
+
+- defines or changes module boundaries
+- changes async data flow, messaging, or background job behavior
+- introduces or retires major infrastructure dependencies
+- changes persistence, consistency, or rollback expectations
+- establishes a long-lived domain workflow that future contributors must preserve
+
+Small implementation details do not need ADRs. Stable architectural constraints do.
+
+## Naming and status
+
+- Store new ADRs as `NNNN-short-title.md`
+- Keep numbering sequential and never reuse retired numbers
+- Start from the template in [template.md](./template.md)
+
+Supported statuses:
+
+- `Proposed`
+- `Accepted`
+- `Superseded`
+- `Deprecated`
+
+If a decision changes, create a new ADR and update the older one to point to the replacement instead of rewriting history.
+
+## Authoring checklist
+
+Each ADR should answer:
+
+- What problem or recurring ambiguity are we resolving?
+- What decision did we make?
+- What tradeoffs did we accept?
+- How should contributors validate or preserve this decision?
+- Which code paths or docs provide the current implementation context?
+
+## ADR Index
+
+- [0001: Use a modular monolith with explicit NestJS domain modules](./0001-modular-monolith-with-domain-modules.md)
+- [0002: Standardize async boundaries with EventEmitter2, RabbitMQ, and Bull](./0002-async-boundaries-with-eventemitter-rabbitmq-and-bull.md)
+- [0003: Use PostgreSQL as the system of record with Redis and RabbitMQ as supporting infrastructure](./0003-postgresql-system-of-record-with-redis-and-rabbitmq.md)
+- [0004: Persist notifications first, then deliver them with retries and DLQ handling](./0004-persist-notifications-with-retry-and-dlq.md)
+- [0005: Treat payment confirmation as the gate for order payment progression](./0005-payment-confirmation-drives-order-progression.md)
+
+## Working agreement
+
+When a pull request changes one of the decisions above, update the affected ADR or add a successor ADR in the same change. This keeps architecture context in the repository rather than in reviewer memory.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,46 @@
+# ADR NNNN: Title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Deciders: @team-or-authors
+- Technical Story: Link the issue, PR, or motivation
+
+## Context
+
+Describe the forces shaping this decision.
+
+- What problem are we solving?
+- What constraints or existing architecture matter?
+- What confusion or regressions happen if we leave this implicit?
+
+## Decision
+
+State the decision clearly and concretely.
+
+- What are we standardizing on?
+- Which modules, layers, or workflows are affected?
+- What rules should contributors follow?
+
+## Consequences
+
+Describe the tradeoffs.
+
+### Positive
+
+- Benefit 1
+- Benefit 2
+
+### Negative
+
+- Cost 1
+- Cost 2
+
+## Validation and follow-up
+
+- How do we verify the decision is being followed?
+- Which tests, docs, or operational checks matter?
+- What follow-up ADRs or implementation work may be needed?
+
+## References
+
+- Link to relevant source files, docs, issues, or PRs

--- a/docs/pr-checklist.md
+++ b/docs/pr-checklist.md
@@ -9,6 +9,7 @@ Purpose: ensure consistent quality, prevent regressions, and make reviews faster
 - Tests: include unit and/or integration tests that cover the change. For bug fixes, add regression tests.
 - Migrations: if schema or data changes are required, add migration files and clear instructions on applying/rolling back.
 - Documentation: update `README.md`, `docs/`, or module-level docs for any user-facing or developer-facing change.
+- ADRs: add or update an ADR in `docs/adr/` when the change affects architecture, module boundaries, infrastructure roles, or long-lived domain workflows.
 - Coverage: run the test suite locally; the change should not reduce global coverage meaningfully for the touched area.
 - Issue link: reference an open issue or explain the motivation if one does not exist.
 - Changelog: add a short entry explaining the user-visible impact (or link to the issue). This helps release notes.
@@ -18,6 +19,7 @@ Purpose: ensure consistent quality, prevent regressions, and make reviews faster
 - [ ] Tests added/updated
 - [ ] Migrations included (if applicable) and instructions provided
 - [ ] Documentation updated
+- [ ] ADR updated or added when architecture changed
 - [ ] Manual verification steps added
 - [ ] CI green (unit + e2e where relevant)
 


### PR DESCRIPTION
Implemented #371.

Added a full ADR workflow under docs/adr/README.md (line 1) with a reusable template at docs/adr/template.md (line 1), plus five seed ADRs covering the repo’s major architectural choices:

ADR 0001 (line 1): modular monolith and module boundaries
ADR 0002 (line 1): EventEmitter2, RabbitMQ, and Bull async boundaries
ADR 0003 (line 1): PostgreSQL as system of record with Redis and RabbitMQ as supporting infra
ADR 0004 (line 1): notification persistence, retries, and DLQ handling
ADR 0005 (line 1): payment confirmation as the gate for order progression
I also wired ADRs into contributor guidance in README.md (line 99) and docs/pr-checklist.md (line 12), so future architecture changes are expected to update an ADR in the same PR. While validating docs, I also removed a broken README link to a missing LICENSE file at README.md (line 152).

closes #371 