### PR TITLE
feat(security): implement route-tiered rate limiting policy (#380)

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -5,9 +5,11 @@ import { AdminService } from './admin.service';
 import { AdminStatsDto } from './dtos/admin-stats.dto';
 import { RolesGuard } from '../guards/roles.guard';
 import { Roles } from '../decorators/roles.decorator';
+import { NoRateLimit } from '../decorators/rate-limit.decorator';
 
 @Controller('admin')
 @UseGuards(RolesGuard)
+@NoRateLimit()
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiTags } from '@nestjs/swagger';
-import { StrictRateLimit } from '../decorators/rate-limit.decorator';
+import { StrictRateLimit, NoRateLimit } from '../decorators/rate-limit.decorator';
 import { RateLimitGuard } from '../guards/rate-limit.guard';
 import { JwtRefreshGuard } from './guards/jwt-refresh.guard';
 import { Enable2FADto } from './dto/enable-2fa.dto';
@@ -16,6 +16,11 @@ import { Verify2FADto } from './dto/verify-2fa.dto';
 
 @ApiTags('auth')
 @Controller('auth')
+@UseGuards(RateLimitGuard)
+@StrictRateLimit({
+  maxRequests: 5,
+  windowMs: 15 * 60 * 1000, // 15 minutes — default for all auth routes
+})
 export class AuthController {
   constructor(private authService: AuthService) {}
 

--- a/src/common/guards/throttle.guard.spec.ts
+++ b/src/common/guards/throttle.guard.spec.ts
@@ -1,0 +1,138 @@
+import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottleGuard } from './throttle.guard';
+import { RATE_LIMIT_CONFIG } from '../config/rate-limit.config';
+
+const makeContext = (ip: string, path: string, userId?: string): ExecutionContext => {
+  const user = userId ? { id: userId } : undefined;
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        user,
+        ip,
+        path,
+        headers: {},
+        socket: { remoteAddress: ip },
+      }),
+      getResponse: () => ({
+        setHeader: jest.fn(),
+      }),
+    }),
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+  } as any;
+};
+
+describe('ThrottleGuard', () => {
+  let guard: ThrottleGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ThrottleGuard, Reflector],
+    }).compile();
+    guard = module.get<ThrottleGuard>(ThrottleGuard);
+  });
+
+  afterEach(() => {
+    // Clear internal state between tests
+    (guard as any).clientRequests.clear();
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should allow requests within the default API limit', () => {
+    const ctx = makeContext('1.2.3.4', '/products');
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('should use LOGIN config limit for /auth/login path', () => {
+    const loginLimit = RATE_LIMIT_CONFIG.LOGIN.limit;
+    const ctx = makeContext('1.2.3.5', '/auth/login');
+
+    // Exhaust the login limit
+    for (let i = 0; i < loginLimit; i++) {
+      expect(guard.canActivate(ctx)).toBe(true);
+    }
+
+    // Next request should be blocked
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+    try {
+      guard.canActivate(ctx);
+    } catch (e) {
+      expect(e.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+    }
+  });
+
+  it('should use PAYMENT config limit for /payments path', () => {
+    const paymentLimit = RATE_LIMIT_CONFIG.PAYMENT.limit;
+    const ctx = makeContext('1.2.3.6', '/payments/initiate');
+
+    for (let i = 0; i < paymentLimit; i++) {
+      expect(guard.canActivate(ctx)).toBe(true);
+    }
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+  });
+
+  it('should use TRANSACTION config limit for /transactions path', () => {
+    const txLimit = RATE_LIMIT_CONFIG.TRANSACTION.limit;
+    const ctx = makeContext('1.2.3.7', '/transactions/my');
+
+    for (let i = 0; i < txLimit; i++) {
+      expect(guard.canActivate(ctx)).toBe(true);
+    }
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+  });
+
+  it('should use SEARCH config limit for /search path', () => {
+    const searchLimit = RATE_LIMIT_CONFIG.SEARCH.limit;
+    const ctx = makeContext('1.2.3.8', '/search');
+
+    for (let i = 0; i < searchLimit; i++) {
+      expect(guard.canActivate(ctx)).toBe(true);
+    }
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+  });
+
+  it('should track authenticated users by user ID, not IP', () => {
+    const ipCtx = makeContext('1.2.3.9', '/products');
+    const userCtx = makeContext('1.2.3.9', '/products', 'user-abc');
+
+    // Both should be tracked independently
+    expect(guard.canActivate(ipCtx)).toBe(true);
+    expect(guard.canActivate(userCtx)).toBe(true);
+
+    const records = (guard as any).clientRequests;
+    expect(records.has('ip:1.2.3.9')).toBe(true);
+    expect(records.has('user:user-abc')).toBe(true);
+  });
+
+  it('should reset a specific client', () => {
+    const ctx = makeContext('1.2.3.10', '/products');
+    guard.canActivate(ctx);
+
+    expect((guard as any).clientRequests.has('ip:1.2.3.10')).toBe(true);
+    const result = guard.resetClient('ip:1.2.3.10');
+    expect(result).toBe(true);
+    expect((guard as any).clientRequests.has('ip:1.2.3.10')).toBe(false);
+  });
+
+  it('should return null status for unknown client', () => {
+    expect(guard.getClientStatus('ip:unknown')).toBeNull();
+  });
+
+  it('should return status for a tracked client', () => {
+    const ctx = makeContext('1.2.3.11', '/products');
+    guard.canActivate(ctx);
+
+    const status = guard.getClientStatus('ip:1.2.3.11');
+    expect(status).not.toBeNull();
+    expect(status!.count).toBe(1);
+    expect(status!.remaining).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/common/guards/throttle.guard.ts
+++ b/src/common/guards/throttle.guard.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
+import { RATE_LIMIT_CONFIG } from '../config/rate-limit.config';
 
 interface RateLimitConfig {
   limit: number;
@@ -21,28 +22,41 @@ interface ClientRecord {
   resetTime: number;
 }
 
+/**
+ * Route-tier mapping: path segment → RATE_LIMIT_CONFIG key.
+ * Ordered from most-specific to least-specific so the first match wins.
+ */
+const ROUTE_TIER_MAP: Array<[string, keyof typeof RATE_LIMIT_CONFIG]> = [
+  ['login', 'LOGIN'],
+  ['register', 'REGISTER'],
+  ['forgot-password', 'PASSWORD_RESET'],
+  ['reset-password', 'PASSWORD_RESET'],
+  ['auth', 'AUTH'],
+  ['payment', 'PAYMENT'],
+  ['transaction', 'TRANSACTION'],
+  ['upload', 'UPLOAD'],
+  ['export', 'EXPORT'],
+  ['search', 'SEARCH'],
+];
+
 @Injectable()
 export class ThrottleGuard implements CanActivate {
   private readonly logger = new Logger(ThrottleGuard.name);
   private clientRequests = new Map<string, ClientRecord>();
   private readonly defaultConfig: RateLimitConfig = {
-    limit: 100,
-    windowMs: 15 * 60 * 1000, // 15 minutes
+    limit: RATE_LIMIT_CONFIG.API.limit,
+    windowMs: RATE_LIMIT_CONFIG.API.windowMs,
     skipSuccessfulRequests: false,
     skipFailedRequests: false,
   };
 
-  // Custom rate limit configs for different endpoint types
-  private readonly endpointConfigs: Map<string, RateLimitConfig> = new Map([
-    ['auth', { limit: 5, windowMs: 15 * 60 * 1000 }], // 5 attempts per 15 minutes
-    ['login', { limit: 5, windowMs: 15 * 60 * 1000 }],
-    ['register', { limit: 3, windowMs: 60 * 60 * 1000 }], // 3 per hour
-    ['password-reset', { limit: 3, windowMs: 60 * 60 * 1000 }],
-    ['api', { limit: 100, windowMs: 15 * 60 * 1000 }], // Standard API: 100 per 15 min
-    ['upload', { limit: 10, windowMs: 60 * 60 * 1000 }], // 10 uploads per hour
-    ['transaction', { limit: 20, windowMs: 60 * 1000 }], // 20 per minute
-    ['payment', { limit: 10, windowMs: 60 * 60 * 1000 }], // 10 per hour
-  ]);
+  // Custom rate limit configs for different endpoint types — sourced from RATE_LIMIT_CONFIG
+  private readonly endpointConfigs: Map<string, RateLimitConfig> = new Map(
+    ROUTE_TIER_MAP.map(([segment, key]) => [
+      segment,
+      { limit: RATE_LIMIT_CONFIG[key].limit, windowMs: RATE_LIMIT_CONFIG[key].windowMs },
+    ]),
+  );
 
   constructor(private reflector: Reflector) {
     // Cleanup expired records every 5 minutes

--- a/src/media/media.controller.ts
+++ b/src/media/media.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import {
@@ -25,9 +26,26 @@ import { MediaService } from './media.service';
 import { QueuedImageUploadResult } from './media.jobs';
 import { UploadImageDto, ReorderImagesDto } from './dto/upload-image.dto';
 import { ProductImage } from './entities/image.entity';
+import { RateLimitGuard } from '../guards/rate-limit.guard';
+import {
+  RateLimit,
+  UserRateLimit,
+} from '../decorators/rate-limit.decorator';
+import { UserTier } from '../rate-limiting/rate-limit.service';
 
 @ApiTags('Media')
 @Controller('media')
+@UseGuards(RateLimitGuard)
+@UserRateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  maxRequests: 10,
+  tierLimits: {
+    [UserTier.FREE]: { maxRequests: 10 },
+    [UserTier.PREMIUM]: { maxRequests: 50 },
+    [UserTier.ENTERPRISE]: { maxRequests: 200 },
+    [UserTier.ADMIN]: { maxRequests: 1000 },
+  },
+})
 export class MediaController {
   constructor(private readonly mediaService: MediaService) {}
 

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -9,6 +9,7 @@ import {
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -30,9 +31,26 @@ import {
   OrderCancelledEvent,
   EventNames,
 } from '../common/events';
+import { RateLimitGuard } from '../guards/rate-limit.guard';
+import {
+  RateLimit,
+  UserRateLimit,
+} from '../decorators/rate-limit.decorator';
+import { UserTier } from '../rate-limiting/rate-limit.service';
 
 @ApiTags('Orders')
 @Controller('orders')
+@UseGuards(RateLimitGuard)
+@UserRateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  maxRequests: 30,
+  tierLimits: {
+    [UserTier.FREE]: { maxRequests: 10 },
+    [UserTier.PREMIUM]: { maxRequests: 50 },
+    [UserTier.ENTERPRISE]: { maxRequests: 200 },
+    [UserTier.ADMIN]: { maxRequests: 1000 },
+  },
+})
 export class OrdersController {
   constructor(
     private readonly ordersService: OrdersService,
@@ -42,6 +60,16 @@ export class OrdersController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @RateLimit({
+    windowMs: 5 * 60 * 1000, // 5 minutes
+    maxRequests: 10,
+    tierLimits: {
+      [UserTier.PREMIUM]: { maxRequests: 30 },
+      [UserTier.ENTERPRISE]: { maxRequests: 100 },
+      [UserTier.ADMIN]: { maxRequests: 1000 },
+    },
+    message: 'Too many orders created. Please wait before placing another order.',
+  })
   async create(@Body() createOrderDto: CreateOrderDto) {
     const order = await this.ordersService.create(createOrderDto);
 

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -28,9 +28,22 @@ import {
   PaymentWebhookDto,
   PaymentCurrency,
 } from './dto/payment.dto';
+import { RateLimitGuard } from '../guards/rate-limit.guard';
+import {
+  StrictRateLimit,
+  RateLimit,
+  NoRateLimit,
+} from '../decorators/rate-limit.decorator';
+import { UserTier } from '../rate-limiting/rate-limit.service';
 
 @ApiTags('Payments')
 @Controller('payments')
+@UseGuards(RateLimitGuard)
+@StrictRateLimit({
+  maxRequests: 10,
+  windowMs: 60 * 60 * 1000, // 10 per hour — strict for all payment routes
+  message: 'Too many payment requests. Please try again later.',
+})
 export class PaymentsController {
   private readonly logger = new Logger(PaymentsController.name);
 
@@ -146,6 +159,7 @@ export class PaymentsController {
    * This endpoint receives transaction callbacks from Stellar Horizon
    */
   @Post('webhook/stellar')
+  @NoRateLimit() // Webhook called by external system — not user-initiated
   @UseGuards(WebhookVerificationGuard)
   @WebhookVerified({
     provider: 'stellar',

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -21,10 +21,27 @@ import { UpdatePriceDto } from './dto/update-price.dto';
 import { SupportedCurrency } from './services/pricing.service';
 import { VerifiedSellerGuard } from '../verification/guards/verified-seller.guard';
 import { CurrencyInterceptor } from '../common/interceptors/currency.interceptor';
+import { RateLimitGuard } from '../guards/rate-limit.guard';
+import {
+  RateLimit,
+  UserRateLimit,
+} from '../decorators/rate-limit.decorator';
+import { UserTier } from '../rate-limiting/rate-limit.service';
 
 @ApiTags('Products')
 @Controller('products')
+@UseGuards(RateLimitGuard)
 @UseInterceptors(CurrencyInterceptor)
+@UserRateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  maxRequests: 30,
+  tierLimits: {
+    [UserTier.FREE]: { maxRequests: 30 },
+    [UserTier.PREMIUM]: { maxRequests: 100 },
+    [UserTier.ENTERPRISE]: { maxRequests: 300 },
+    [UserTier.ADMIN]: { maxRequests: 1000 },
+  },
+})
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 
@@ -49,6 +66,16 @@ export class ProductsController {
   @ApiBearerAuth()
   @UseGuards(VerifiedSellerGuard)
   @ApiOperation({ summary: 'Create product (verified seller only)' })
+  @RateLimit({
+    windowMs: 5 * 60 * 1000, // 5 minutes
+    maxRequests: 10,
+    tierLimits: {
+      [UserTier.PREMIUM]: { maxRequests: 30 },
+      [UserTier.ENTERPRISE]: { maxRequests: 100 },
+      [UserTier.ADMIN]: { maxRequests: 1000 },
+    },
+    message: 'Too many products created. Please wait before creating more.',
+  })
   create(@Req() req, @Body() dto: CreateProductDto) {
     return this.productsService.create(req.user.id.toString(), dto);
   }

--- a/src/rate-limiting/rate-limiting.module.ts
+++ b/src/rate-limiting/rate-limiting.module.ts
@@ -1,12 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { RateLimitService } from './rate-limit.service';
 
 @Module({
   providers: [RateLimitService],
   exports: [RateLimitService],
 })
-export class RateLimitingModule {
-  constructor(private readonly rateLimitService: RateLimitService) {
-    this.rateLimitService.configure();
+export class RateLimitingModule implements OnModuleInit {
+  constructor(private readonly rateLimitService: RateLimitService) {}
+
+  async onModuleInit() {
+    await this.rateLimitService.loadConfigurations();
   }
 }

--- a/src/rate-limiting/tests/rate-limit.service.spec.ts
+++ b/src/rate-limiting/tests/rate-limit.service.spec.ts
@@ -200,4 +200,46 @@ describe('RateLimitService', () => {
       expect(analytics[0].data[0].identifier).toBe('user:123');
     });
   });
+
+  describe('loadConfigurations', () => {
+    it('should load tier configs from Redis on startup', async () => {
+      mockRedis.get = jest.fn().mockResolvedValue(
+        JSON.stringify({ windowMs: 30000, maxRequests: 25, burstAllowance: 5 }),
+      );
+      mockRedis.keys = jest.fn().mockResolvedValue([]);
+
+      await service.loadConfigurations();
+
+      // get should have been called once per UserTier
+      expect(mockRedis.get).toHaveBeenCalledWith(
+        expect.stringContaining('rate_limit_config:tier:'),
+      );
+    });
+
+    it('should load endpoint configs from Redis on startup', async () => {
+      mockRedis.get = jest.fn().mockResolvedValue(null);
+      mockRedis.keys = jest.fn().mockResolvedValue([
+        'rate_limit_config:endpoint:/api/custom',
+      ]);
+      // Second call for the endpoint key
+      mockRedis.get = jest
+        .fn()
+        .mockResolvedValueOnce(null) // tier keys return null
+        .mockResolvedValueOnce(
+          JSON.stringify({ windowMs: 60000, maxRequests: 15 }),
+        );
+
+      await service.loadConfigurations();
+
+      expect(mockRedis.keys).toHaveBeenCalledWith(
+        'rate_limit_config:endpoint:*',
+      );
+    });
+
+    it('should not throw when Redis is unavailable during load', async () => {
+      mockRedis.get = jest.fn().mockRejectedValue(new Error('Redis down'));
+
+      await expect(service.loadConfigurations()).resolves.not.toThrow();
+    });
+  });
 });

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,11 +1,26 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
 
 import { SearchService } from './search.service';
 import { SearchQueryDto } from './dto/search-query.dto';
+import { RateLimitGuard } from '../guards/rate-limit.guard';
+import { UserRateLimit } from '../decorators/rate-limit.decorator';
+import { UserTier } from '../rate-limiting/rate-limit.service';
 
 @ApiTags('Search')
 @Controller('search')
+@UseGuards(RateLimitGuard)
+@UserRateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  maxRequests: 30,
+  burstAllowance: 5,
+  tierLimits: {
+    [UserTier.FREE]: { maxRequests: 30 },
+    [UserTier.PREMIUM]: { maxRequests: 100 },
+    [UserTier.ENTERPRISE]: { maxRequests: 300 },
+    [UserTier.ADMIN]: { maxRequests: 1000 },
+  },
+})
 export class SearchController {
   constructor(private readonly searchService: SearchService) {}
 

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -19,6 +19,9 @@ import {
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TransactionsService } from './transactions.service';
 import { Transaction } from './entities/transaction.entity';
+import { RateLimitGuard } from '../guards/rate-limit.guard';
+import { UserRateLimit } from '../decorators/rate-limit.decorator';
+import { UserTier } from '../rate-limiting/rate-limit.service';
 
 interface AuthenticatedRequest extends Request {
   user: {
@@ -31,7 +34,17 @@ interface AuthenticatedRequest extends Request {
 @ApiTags('Transactions')
 @Controller('transactions')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RateLimitGuard)
+@UserRateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  maxRequests: 20,
+  tierLimits: {
+    [UserTier.FREE]: { maxRequests: 20 },
+    [UserTier.PREMIUM]: { maxRequests: 60 },
+    [UserTier.ENTERPRISE]: { maxRequests: 200 },
+    [UserTier.ADMIN]: { maxRequests: 1000 },
+  },
+})
 export class TransactionsController {
   private readonly logger = new Logger(TransactionsController.name);
 


### PR DESCRIPTION
## Summary

Implements a consistent, route-tiered rate limiting policy across all major endpoint classes, closing issue #380.

## Changes

### Bug fix
- **`RateLimitingModule`**: replaced the broken `configure()` call (method doesn't exist) with `loadConfigurations()` via `OnModuleInit`, so persisted Redis configs are loaded on startup.

### ThrottleGuard upgrade
- **`ThrottleGuard`** (global `APP_GUARD`): replaced hardcoded per-route numbers with a `ROUTE_TIER_MAP` that derives limits directly from `RATE_LIMIT_CONFIG`. All routes now get a consistent, centrally-configured baseline.

### Route-tiered policy applied to controllers

| Controller | Tier | Limit |
|---|---|---|
| `AuthController` | STRICT | 5 req / 15 min, no burst |
| `PaymentsController` | STRICT | 10 req / hr, no burst |
| `OrdersController` (POST) | WRITE | 10 req / 5 min, tier-scaled |
| `TransactionsController` | WRITE | 20 req / min, tier-scaled |
| `ProductsController` (POST) | WRITE | 10 req / 5 min, tier-scaled |
| `SearchController` | READ | 30 req / 5 min + burst |
| `MediaController` | UPLOAD | 10 req / hr, tier-scaled |
| `AdminController` | EXEMPT | `@NoRateLimit()` |
| `PaymentsController` webhook | EXEMPT | `@NoRateLimit()` (external system) |

### Tests
- New `throttle.guard.spec.ts`: covers route-tier mapping for login, payment, transaction, search paths; client tracking by user ID vs IP; reset and status helpers.
- Updated `rate-limit.service.spec.ts`: added `loadConfigurations` tests (loads tier configs, loads endpoint configs, fails gracefully when Redis is down).

## Testing

```bash
npm test -- --testPathPattern="rate-limit|throttle"
```

## Related
Closes #380