### PR TITLE
feat(disputes): implement arbitration dispute resolution workflow 

### DIFF
--- a/src/dispute/disputes.controller.ts
+++ b/src/dispute/disputes.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Post, Get, Patch, Param, Body, UseGuards, Request, ParseUUIDPipe, ValidationPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { DisputesService } from './disputes.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { AdminGuard } from '../common/guards/admin.guard'; // Matches project guard references
+import { ResolutionAction } from './disputes.entity';
+
+@ApiTags('Dispute Resolution')
+@Controller()
+export class DisputesController {
+  constructor(private readonly disputesService: DisputesService) {}
+
+  @ApiOperation({ summary: 'Raise a dispute on an active order' })
+  @ApiBody({ schema: { type: 'object', required: ['reason'], properties: { reason: { type: 'string', example: 'Product received damaged.' } } } })
+  @UseGuards(JwtAuthGuard)
+  @Post('orders/:id/dispute')
+  async raise(
+    @Param('id', ParseUUIDPipe) orderId: string,
+    @Body('reason') reason: string,
+    @Request() req,
+  ) {
+    if (!reason || reason.trim().length === 0) {
+      throw new Error('A valid material reason text is required to file a dispute record.');
+    }
+    // Parses user identity key cleanly to an integer number format
+    return await this.disputesService.raiseDispute(orderId, Number(req.user.id), reason);
+  }
+
+  @ApiOperation({ summary: 'List all ongoing platform disputes (Admin Only)' })
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Get('disputes')
+  async listOpenCases() {
+    return await this.disputesService.findAllOpenDisputes();
+  }
+
+  @ApiOperation({ summary: 'Resolve a pending dispute case (Admin Only)' })
+  @ApiBody({ schema: { type: 'object', required: ['resolution', 'action'], properties: { resolution: { type: 'string' }, action: { type: 'string', enum: ['REFUND_TO_BUYER', 'RELEASE_TO_SELLER'] } } } })
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Patch('disputes/:id/resolve')
+  async resolve(
+    @Param('id', ParseUUIDPipe) disputeId: string,
+    @Body('resolution') resolution: string,
+    @Body('action') action: ResolutionAction,
+  ) {
+    if (!resolution || !action) {
+      throw new Error('Resolution explanatory texts and explicit resolution target action steps are required.');
+    }
+    return await this.disputesService.resolveDispute(disputeId, resolution, action);
+  }
+}

--- a/src/dispute/disputes.entity.ts
+++ b/src/dispute/disputes.entity.ts
@@ -1,0 +1,51 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export enum DisputeStatus {
+  OPEN = 'OPEN',
+  UNDER_REVIEW = 'UNDER_REVIEW',
+  RESOLVED = 'RESOLVED',
+}
+
+export enum ResolutionAction {
+  REFUND_TO_BUYER = 'REFUND_TO_BUYER',
+  RELEASE_TO_SELLER = 'RELEASE_TO_SELLER',
+}
+
+@Entity('disputes')
+export class Dispute {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'order_id' })
+  orderId: string;
+
+  // Aligned to match our production sequential integer user identity column type
+  @Column({ name: 'raised_by', type: 'integer' })
+  raisedBy: number;
+
+  @Column({ type: 'text' })
+  reason: string;
+
+  @Column({
+    type: 'enum',
+    enum: DisputeStatus,
+    default: DisputeStatus.OPEN,
+  })
+  status: DisputeStatus;
+
+  @Column({ type: 'text', nullable: true })
+  resolution?: string;
+
+  @Column({
+    type: 'enum',
+    enum: ResolutionAction,
+    nullable: true,
+  })
+  resolutionAction?: ResolutionAction;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/dispute/disputes.module.ts
+++ b/src/dispute/disputes.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DisputesService } from './disputes.service';
+import { DisputesController } from './disputes.controller';
+import { Dispute } from './disputes.entity';
+import { OrdersModule } from '../orders/orders.module'; // Import module to leverage inner service calls safely
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Dispute]),
+    OrdersModule, // Wired up cleanly to utilize ordersService state management definitions
+  ],
+  providers: [DisputesService],
+  controllers: [DisputesController],
+  exports: [DisputesService],
+})
+export class DisputesModule {}

--- a/src/dispute/disputes.service.ts
+++ b/src/dispute/disputes.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Dispute, DisputeStatus, ResolutionAction } from './disputes.entity';
+import { OrdersService } from '../orders/orders.service'; // Assuming standard service access paths
+
+@Injectable()
+export class DisputesService {
+  constructor(
+    @InjectRepository(Dispute)
+    private readonly disputesRepository: Repository<Dispute>,
+    private readonly ordersService: OrdersService,
+  ) {}
+
+  /**
+   * Instantiates a new dispute record attached to an eligible order status code
+   */
+  async raiseDispute(orderId: string, raisedBy: number, reason: string): Promise<Dispute> {
+    const order = await this.ordersService.findOne(orderId);
+    if (!order) {
+      throw new NotFoundException(`Order with ID ${orderId} does not exist.`);
+    }
+
+    // Force validation conditions over the core active order state machine flags
+    const acceptableStates = ['SHIPPED', 'DELIVERED'];
+    if (!acceptableStates.includes(order.status)) {
+      throw new BadRequestException(
+        `Disputes can only be raised when order lifecycle status is SHIPPED or DELIVERED. Current: ${order.status}`,
+      );
+    }
+
+    // Check if a dispute already exists for this order
+    const existingDispute = await this.disputesRepository.findOne({ where: { orderId } });
+    if (existingDispute) {
+      throw new BadRequestException('A dispute case has already been registered for this order reference.');
+    }
+
+    const dispute = this.disputesRepository.create({
+      orderId,
+      raisedBy,
+      reason,
+      status: DisputeStatus.OPEN,
+    });
+
+    return await this.disputesRepository.save(dispute);
+  }
+
+  /**
+   * Fetches all active non-finalized cases for global admin monitoring dashboards
+   */
+  async findAllOpenDisputes(): Promise<Dispute[]> {
+    return await this.disputesRepository.find({
+      where: [
+        { status: DisputeStatus.OPEN },
+        { status: DisputeStatus.UNDER_REVIEW },
+      ],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Closes a dispute case by triggering automated escrow actions based on resolution decisions
+   */
+  async resolveDispute(
+    disputeId: string,
+    resolution: string,
+    action: ResolutionAction,
+  ): Promise<Dispute> {
+    const dispute = await this.disputesRepository.findOne({ where: { id: disputeId } });
+    if (!dispute) {
+      throw new NotFoundException(`Dispute instance ${disputeId} could not be resolved.`);
+    }
+
+    if (dispute.status === DisputeStatus.RESOLVED) {
+      throw new BadRequestException('This dispute case file has already been marked as RESOLVED.');
+    }
+
+    // Process escrow modifications by passing execution mandates down to your order tiers
+    if (action === ResolutionAction.REFUND_TO_BUYER) {
+      await this.ordersService.updateStatus(dispute.orderId, { status: 'DISPUTE_REFUNDED' } as any);
+    } else if (action === ResolutionAction.RELEASE_TO_SELLER) {
+      await this.ordersService.updateStatus(dispute.orderId, { status: 'DISPUTE_RELEASED' } as any);
+    }
+
+    dispute.status = DisputeStatus.RESOLVED;
+    dispute.resolution = resolution;
+    dispute.resolutionAction = action;
+
+    return await this.disputesRepository.save(dispute);
+  }
+}


### PR DESCRIPTION
## Description
This PR resolves issue #430 by adding the complete dispute resolution framework layer on top of our existing order processing mechanisms.

## System Changes
* **Order Guard Boundaries:** Bound strict entry verification checks ensuring dispute filings are rejected unless the target transaction state reads `SHIPPED` or `DELIVERED`.
* **Escrow Interception Mechanics:** Refactored the completion hooks to programmatically change order status tracks (`DISPUTE_REFUNDED` / `DISPUTE_RELEASED`) depending on the admin's final action decisions.
* **Role Enforcement:** Applied explicit `AdminGuard` middleware blocks across management routes, protecting case lists and settlement execution streams from general user access.