### PR TITLE
Add unit tests for AuthService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4584,7 +4584,7 @@
       "version": "11.1.19",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.19.tgz",
       "integrity": "sha512-gu1nPIEaP5Qjjg/Cl8wXyvwGpdZGzgbtK4KcH65YRAA+GTKUkIHb4BNpLJ27Ymq/wqLJKNEbCjajfzD0BEjMGA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "socket.io": "4.8.3",
@@ -6540,7 +6540,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sqltools/formatter": {
@@ -7251,7 +7251,7 @@
       "version": "1.15.32",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.32.tgz",
       "integrity": "sha512-/eWL0n43D64QWEUHLtTE+jDqjkJhyidjkDhv6f0uJohOUAhywxQ9wXYp845DNNds0JpCdI4Uo0a9bl+vbXf+ew==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7295,7 +7295,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7312,7 +7311,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7329,7 +7327,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7346,7 +7343,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7363,7 +7359,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7380,7 +7375,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7397,7 +7391,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7414,7 +7407,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7431,7 +7423,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7448,7 +7439,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7465,7 +7455,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7482,7 +7471,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7496,7 +7484,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -7512,7 +7500,7 @@
       "version": "0.1.26",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
       "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -7717,7 +7705,7 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8268,7 +8256,7 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -10218,7 +10206,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
@@ -12321,7 +12309,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
       "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -12357,7 +12345,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12367,7 +12355,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -12381,7 +12369,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12391,7 +12379,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -12404,7 +12392,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -19240,7 +19228,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
       "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
@@ -19259,7 +19247,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
       "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
@@ -19286,7 +19274,7 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
       "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -19300,7 +19288,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -19314,7 +19302,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -19324,7 +19312,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -19337,7 +19325,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -21911,7 +21899,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@scure|@noble|otplib)/)"
+      "node_modules/(?!(.pnpm|@scure|@noble|otplib)/)",
+      "node_modules/@otplib/node_modules/(?!(.pnpm|@scure|@noble)/)"
     ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,370 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, UnauthorizedException, ForbiddenException, BadRequestException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { TokenRegistryService } from './token-registry.service';
+import * as bcrypt from 'bcrypt';
+
+// Mock otplib to avoid ES module transformation issues
+jest.mock('otplib', () => ({
+  generateSecret: jest.fn(),
+  generateURI: jest.fn(),
+  verify: jest.fn(),
+}));
+
+const otplib = require('otplib');
+
+// Mock qrcode to avoid ES module transformation issues
+jest.mock('qrcode', () => ({
+  toDataURL: jest.fn(),
+}));
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let usersService: UsersService;
+  let jwtService: JwtService;
+  let tokenRegistry: TokenRegistryService;
+  let eventEmitter: EventEmitter2;
+
+  const mockUser = {
+    id: 1,
+    email: 'test@example.com',
+    password: 'hashedPassword',
+    name: 'Test User',
+    twoFAEnabled: false,
+    twoFASecret: null,
+  };
+
+  const getMockUser = (email: string) => ({
+    ...mockUser,
+    email,
+  });
+
+  const mockTokens = {
+    accessToken: 'mock-access-token',
+    refreshToken: 'mock-refresh-token',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: UsersService,
+          useValue: {
+            create: jest.fn(),
+            findByEmail: jest.fn(),
+            findOne: jest.fn(),
+            update2FA: jest.fn(),
+            updatePassword: jest.fn(),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            signAsync: jest.fn(),
+            sign: jest.fn(),
+          },
+        },
+        {
+          provide: TokenRegistryService,
+          useValue: {
+            store: jest.fn(),
+            exists: jest.fn(),
+            invalidate: jest.fn(),
+            invalidateAllForUser: jest.fn(),
+          },
+        },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
+            on: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    usersService = module.get<UsersService>(UsersService);
+    jwtService = module.get<JwtService>(JwtService);
+    tokenRegistry = module.get<TokenRegistryService>(TokenRegistryService);
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+
+    // Reset mocks before each test
+    jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('should hash password and return tokens on successful registration', async () => {
+      const registerDto = {
+        email: 'new@example.com',
+        password: 'plainPassword',
+        firstName: 'John',
+        lastName: 'Doe',
+      };
+
+      const bcryptHashSpy = jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashedPassword' as never);
+      (usersService.create as jest.Mock).mockResolvedValue(getMockUser('new@example.com'));
+      (jwtService.signAsync as jest.Mock).mockResolvedValue(mockTokens.accessToken);
+      (tokenRegistry.store as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.register(registerDto);
+
+      expect(bcryptHashSpy).toHaveBeenCalledWith('plainPassword', 10);
+      expect(usersService.create).toHaveBeenCalledWith({
+        email: 'new@example.com',
+        password: 'hashedPassword',
+        name: 'John Doe',
+      });
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { sub: '1', email: 'new@example.com' },
+        { expiresIn: '15m' },
+      );
+      expect(tokenRegistry.store).toHaveBeenCalledWith('1', expect.any(String));
+      expect(result.accessToken).toBe(mockTokens.accessToken);
+      expect(result.refreshToken).toBeDefined();
+    });
+
+    it('should throw ConflictException on duplicate email', async () => {
+      const registerDto = {
+        email: 'existing@example.com',
+        password: 'plainPassword',
+      };
+
+      const conflictError = new ConflictException('Email already exists');
+      (usersService.create as jest.Mock).mockRejectedValue(conflictError);
+
+      await expect(service.register(registerDto)).rejects.toThrow(ConflictException);
+    });
+
+    it('should use name from firstName and lastName when provided', async () => {
+      const registerDto = {
+        email: 'new@example.com',
+        password: 'plainPassword',
+        firstName: 'Jane',
+        lastName: 'Smith',
+      };
+
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashedPassword' as never);
+      (usersService.create as jest.Mock).mockResolvedValue(mockUser);
+      (jwtService.signAsync as jest.Mock).mockResolvedValue(mockTokens.accessToken);
+      (tokenRegistry.store as jest.Mock).mockResolvedValue(undefined);
+
+      await service.register(registerDto);
+
+      expect(usersService.create).toHaveBeenCalledWith({
+        email: 'new@example.com',
+        password: 'hashedPassword',
+        name: 'Jane Smith',
+      });
+    });
+
+    it('should use email as name when no name fields provided', async () => {
+      const registerDto = {
+        email: 'new@example.com',
+        password: 'plainPassword',
+      };
+
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashedPassword' as never);
+      (usersService.create as jest.Mock).mockResolvedValue(mockUser);
+      (jwtService.signAsync as jest.Mock).mockResolvedValue(mockTokens.accessToken);
+      (tokenRegistry.store as jest.Mock).mockResolvedValue(undefined);
+
+      await service.register(registerDto);
+
+      expect(usersService.create).toHaveBeenCalledWith({
+        email: 'new@example.com',
+        password: 'hashedPassword',
+        name: 'new@example.com',
+      });
+    });
+  });
+
+  describe('validateUser (login)', () => {
+    it('should throw UnauthorizedException when user not found', async () => {
+      (usersService.findByEmail as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.validateUser('nonexistent@example.com', 'password')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.validateUser('nonexistent@example.com', 'password')).rejects.toThrow(
+        'Invalid credentials',
+      );
+    });
+
+    it('should throw UnauthorizedException when password is incorrect', async () => {
+      (usersService.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await expect(service.validateUser('test@example.com', 'wrongPassword')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.validateUser('test@example.com', 'wrongPassword')).rejects.toThrow(
+        'Invalid credentials',
+      );
+    });
+
+    it('should throw UnauthorizedException when user has no password', async () => {
+      const userWithoutPassword = { ...mockUser, password: null };
+      (usersService.findByEmail as jest.Mock).mockResolvedValue(userWithoutPassword);
+
+      await expect(service.validateUser('test@example.com', 'password')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should return tokens on valid credentials', async () => {
+      (usersService.findByEmail as jest.Mock).mockResolvedValue(mockUser);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+      (jwtService.signAsync as jest.Mock).mockResolvedValue(mockTokens.accessToken);
+      (tokenRegistry.store as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.validateUser('test@example.com', 'correctPassword');
+
+      expect(bcrypt.compare).toHaveBeenCalledWith('correctPassword', 'hashedPassword');
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { sub: '1', email: 'test@example.com' },
+        { expiresIn: '15m' },
+      );
+      expect(tokenRegistry.store).toHaveBeenCalledWith('1', expect.any(String));
+      expect(result.accessToken).toBe(mockTokens.accessToken);
+      expect(result.refreshToken).toBeDefined();
+    });
+  });
+
+  describe('refreshTokens', () => {
+    it('should throw ForbiddenException when refresh token is invalid/expired', async () => {
+      (tokenRegistry.exists as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        service.refreshTokens('1', 'test@example.com', 'invalid-token'),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.refreshTokens('1', 'test@example.com', 'invalid-token'),
+      ).rejects.toThrow('Access Denied: Refresh token reuse detected.');
+      expect(tokenRegistry.invalidateAllForUser).toHaveBeenCalledWith('1');
+    });
+
+    it('should invalidate old token and return new tokens on valid refresh', async () => {
+      (tokenRegistry.exists as jest.Mock).mockResolvedValue(true);
+      (tokenRegistry.invalidate as jest.Mock).mockResolvedValue(undefined);
+      (jwtService.signAsync as jest.Mock).mockResolvedValue(mockTokens.accessToken);
+      (tokenRegistry.store as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.refreshTokens('1', 'test@example.com', 'valid-token');
+
+      expect(tokenRegistry.exists).toHaveBeenCalledWith('1', 'valid-token');
+      expect(tokenRegistry.invalidate).toHaveBeenCalledWith('1', 'valid-token');
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { sub: '1', email: 'test@example.com' },
+        { expiresIn: '15m' },
+      );
+      expect(tokenRegistry.store).toHaveBeenCalledWith('1', expect.any(String));
+      expect(result.accessToken).toBe(mockTokens.accessToken);
+      expect(result.refreshToken).toBeDefined();
+    });
+
+    it('should revoke all user tokens when reuse is detected', async () => {
+      (tokenRegistry.exists as jest.Mock).mockResolvedValue(false);
+      (tokenRegistry.invalidateAllForUser as jest.Mock).mockResolvedValue(undefined);
+
+      await expect(
+        service.refreshTokens('1', 'test@example.com', 'reused-token'),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(tokenRegistry.invalidateAllForUser).toHaveBeenCalledWith('1');
+    });
+  });
+
+  describe('enable2FA', () => {
+    it('should generate TOTP secret and return QR code', async () => {
+      const mockSecret = 'JBSWY3DPEHPK3PXP';
+      const mockOtpauth = 'otpauth://totp/MarketX:1?secret=JBSWY3DPEHPK3PXP&issuer=MarketX';
+      const mockQrCode = 'data:image/png;base64,mockqr';
+
+      jest.spyOn(otplib, 'generateSecret').mockReturnValue(mockSecret);
+      jest.spyOn(otplib, 'generateURI').mockReturnValue(mockOtpauth);
+      const qrcode = require('qrcode');
+      jest.spyOn(qrcode, 'toDataURL').mockResolvedValue(mockQrCode);
+
+      (usersService.update2FA as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.enable2FA('1');
+
+      expect(otplib.generateSecret).toHaveBeenCalled();
+      expect(usersService.update2FA).toHaveBeenCalledWith(1, mockSecret, true);
+      expect(result.qrCodeDataURL).toBeDefined();
+      expect(result.otpauth).toBe(mockOtpauth);
+    });
+  });
+
+  describe('verify2FA', () => {
+    it('should throw BadRequestException when 2FA is not enabled for user', async () => {
+      const userWithout2FA = { ...mockUser, twoFAEnabled: false, twoFASecret: null };
+      (usersService.findOne as jest.Mock).mockResolvedValue(userWithout2FA);
+
+      await expect(service.verify2FA('1', '123456')).rejects.toThrow(BadRequestException);
+      await expect(service.verify2FA('1', '123456')).rejects.toThrow('2FA not enabled for this user');
+    });
+
+    it('should throw BadRequestException when user not found', async () => {
+      (usersService.findOne as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.verify2FA('1', '123456')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when TOTP code is invalid', async () => {
+      const userWith2FA = { ...mockUser, twoFAEnabled: true, twoFASecret: 'JBSWY3DPEHPK3PXP' };
+      (usersService.findOne as jest.Mock).mockResolvedValue(userWith2FA);
+      jest.spyOn(otplib, 'verify').mockResolvedValue({ valid: false } as never);
+
+      await expect(service.verify2FA('1', '000000')).rejects.toThrow(BadRequestException);
+      await expect(service.verify2FA('1', '000000')).rejects.toThrow('Invalid 2FA code');
+    });
+
+    it('should return true when TOTP code is valid', async () => {
+      const userWith2FA = { ...mockUser, twoFAEnabled: true, twoFASecret: 'JBSWY3DPEHPK3PXP' };
+      (usersService.findOne as jest.Mock).mockResolvedValue(userWith2FA);
+      jest.spyOn(otplib, 'verify').mockResolvedValue({ valid: true, delta: 0 });
+
+      const result = await service.verify2FA('1', '123456');
+
+      expect(otplib.verify).toHaveBeenCalledWith({
+        secret: 'JBSWY3DPEHPK3PXP',
+        token: '123456',
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('revokeAllUserTokens', () => {
+    it('should invalidate all tokens for a user', async () => {
+      (tokenRegistry.invalidateAllForUser as jest.Mock).mockResolvedValue(undefined);
+
+      await service.revokeAllUserTokens('1');
+
+      expect(tokenRegistry.invalidateAllForUser).toHaveBeenCalledWith('1');
+    });
+  });
+
+  describe('getTokens', () => {
+    it('should generate access and refresh tokens', async () => {
+      (jwtService.signAsync as jest.Mock).mockResolvedValue(mockTokens.accessToken);
+      (tokenRegistry.store as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await service.getTokens('1', 'test@example.com');
+
+      expect(jwtService.signAsync).toHaveBeenCalledWith(
+        { sub: '1', email: 'test@example.com' },
+        { expiresIn: '15m' },
+      );
+      expect(tokenRegistry.store).toHaveBeenCalledWith('1', expect.any(String));
+      expect(result.accessToken).toBe(mockTokens.accessToken);
+      expect(result.refreshToken).toBeDefined();
+      expect(result.refreshToken).toHaveLength(80); // 40 bytes * 2 hex chars
+    });
+  });
+});


### PR DESCRIPTION
Closes #440 
This PR adds complete test coverage for the AuthService with 18 unit tests covering:
 
- **register()**: Password hashing verification, ConflictException for duplicate emails, and name handling
- **validateUser (login)**: UnauthorizedException for invalid credentials and token generation for valid login
- **refreshTokens()**: ForbiddenException for invalid/expired tokens, token rotation, and reuse detection
- **enableTwoFactor() / verifyTwoFactor()**: TOTP secret generation, QR code generation, and verification flow
 
Also includes Jest configuration updates to handle ES module transformation issues for otplib and qrcode dependencies.
 
All tests passing (18/18).