### PR TITLE
feat(disputes): implement order dispute resolution workflow modules

### DIFF
--- a/src/dispute/disputes.controller.ts
+++ b/src/dispute/disputes.controller.ts
@@ -8,11 +8,12 @@ import {
   UseGuards,
   Request,
   ParseUUIDPipe,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBody } from '@nestjs/swagger';
 import { DisputesService } from './disputes.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { AdminGuard } from '../guards/admin.guard'; // Matches project guard references
+import { AdminGuard } from '../guards/admin.guard';
 import { ResolutionAction } from './disputes.entity';
 
 @ApiTags('Dispute Resolution')
@@ -38,11 +39,11 @@ export class DisputesController {
     @Request() req,
   ) {
     if (!reason || reason.trim().length === 0) {
-      throw new Error(
+      throw new BadRequestException(
         'A valid material reason text is required to file a dispute record.',
       );
     }
-    // Parses user identity key cleanly to an integer number format
+
     return await this.disputesService.raiseDispute(
       orderId,
       Number(req.user.id),
@@ -63,7 +64,7 @@ export class DisputesController {
       type: 'object',
       required: ['resolution', 'action'],
       properties: {
-        resolution: { type: 'string' },
+        resolution: { type: 'string', example: 'Item returned tracking confirmed. Refunding buyer.' },
         action: {
           type: 'string',
           enum: ['REFUND_TO_BUYER', 'RELEASE_TO_SELLER'],
@@ -78,11 +79,13 @@ export class DisputesController {
     @Body('resolution') resolution: string,
     @Body('action') action: ResolutionAction,
   ) {
-    if (!resolution || !action) {
-      throw new Error(
-        'Resolution explanatory texts and explicit resolution target action steps are required.',
-      );
+    if (!resolution || !resolution.trim()) {
+      throw new BadRequestException('Resolution explanatory text is required.');
     }
+    if (!action) {
+      throw new BadRequestException('An explicit resolution target action step is required.');
+    }
+
     return await this.disputesService.resolveDispute(
       disputeId,
       resolution,

--- a/src/dispute/disputes.entity.ts
+++ b/src/dispute/disputes.entity.ts
@@ -22,10 +22,9 @@ export class Dispute {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ name: 'order_id' })
+  @Column({ name: 'order_id', type: 'uuid' })
   orderId: string;
 
-  // Aligned to match our production sequential integer user identity column type
   @Column({ name: 'raised_by', type: 'integer' })
   raisedBy: number;
 

--- a/src/dispute/disputes.module.ts
+++ b/src/dispute/disputes.module.ts
@@ -3,12 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DisputesService } from './disputes.service';
 import { DisputesController } from './disputes.controller';
 import { Dispute } from './disputes.entity';
-import { OrdersModule } from '../orders/orders.module'; // Import module to leverage inner service calls safely
+import { OrdersModule } from '../orders/orders.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Dispute]),
-    OrdersModule, // Wired up cleanly to utilize ordersService state management definitions
+    OrdersModule,
   ],
   providers: [DisputesService],
   controllers: [DisputesController],

--- a/src/dispute/disputes.service.ts
+++ b/src/dispute/disputes.service.ts
@@ -6,7 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Dispute, DisputeStatus, ResolutionAction } from './disputes.entity';
-import { OrdersService } from '../orders/orders.service'; // Assuming standard service access paths
+import { OrdersService } from '../orders/orders.service';
 
 @Injectable()
 export class DisputesService {
@@ -31,13 +31,13 @@ export class DisputesService {
 
     // Force validation conditions over the core active order state machine flags
     const acceptableStates = ['SHIPPED', 'DELIVERED'];
-    if (!acceptableStates.includes(order.status)) {
+    if (!acceptableStates.includes(order.status?.toUpperCase())) {
       throw new BadRequestException(
         `Disputes can only be raised when order lifecycle status is SHIPPED or DELIVERED. Current: ${order.status}`,
       );
     }
 
-    // Check if a dispute already exists for this order
+    // Verify if an active dispute already tracks this order context
     const existingDispute = await this.disputesRepository.findOne({
       where: { orderId },
     });


### PR DESCRIPTION
Summary

- Adds TypeORM Dispute schema architecture tracking order validation context states
- Restricts dispute initializations strictly to active SHIPPED or DELIVERED orders
- Secures dashboard data aggregation and patch streams behind core AdminGuards
- Hooks resolving states into atomic escrow release or refund execution layers
- Closes #430" && \
