### PR TITLE
[security] Add replay protection and remove hardcoded fallback secret on Stellar webhook

### DIFF
--- a/src/webhooks/stellar-webhook.controller.spec.ts
+++ b/src/webhooks/stellar-webhook.controller.spec.ts
@@ -6,13 +6,15 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { LoggerService } from '../common/logger/logger.service';
 import { getQueueToken } from '@nestjs/bull';
-import { UnauthorizedException } from '@nestjs/common';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import * as crypto from 'crypto';
 
 describe('StellarWebhookController', () => {
   let controller: StellarWebhookController;
   let queue: any;
   let logger: any;
+  let cacheStore: Map<string, string>;
 
   const mockQueue = {
     add: jest.fn().mockResolvedValue({ id: 'job-id' }),
@@ -27,13 +29,38 @@ describe('StellarWebhookController', () => {
     }),
   };
 
+  const mockCache = {
+    get: jest.fn((key: string) => Promise.resolve(cacheStore.get(key))),
+    set: jest.fn((key: string, value: string) => {
+      cacheStore.set(key, value);
+      return Promise.resolve();
+    }),
+  };
+
   const mockLogger = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
   };
 
+  const signBody = (body: StellarWebhookDto) =>
+    crypto
+      .createHmac('sha256', 'test-secret')
+      .update(JSON.stringify(body))
+      .digest('hex');
+
+  const makeBody = (overrides: Partial<StellarWebhookDto> = {}) => ({
+    eventId: 'evt-123',
+    timestamp: new Date().toISOString(),
+    transactionHash: 'tx-hash-123',
+    amount: '100.00',
+    status: 'confirmed',
+    ...overrides,
+  });
+
   beforeEach(async () => {
+    cacheStore = new Map();
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [StellarWebhookController],
       providers: [
@@ -44,6 +71,10 @@ describe('StellarWebhookController', () => {
         {
           provide: ConfigService,
           useValue: mockConfigService,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCache,
         },
         {
           provide: LoggerService,
@@ -63,18 +94,17 @@ describe('StellarWebhookController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should successfully validate signature and add to queue', async () => {
-    const body: StellarWebhookDto = {
-      transactionHash: 'tx-hash-123',
-      amount: '100.00',
-      status: 'confirmed',
-    };
+  it('should fail startup when STELLAR_WEBHOOK_SECRET is missing', () => {
+    mockConfigService.get.mockReturnValueOnce(undefined);
 
-    const payload = JSON.stringify(body);
-    const expectedSignature = crypto
-      .createHmac('sha256', 'test-secret')
-      .update(payload)
-      .digest('hex');
+    expect(() => controller.onModuleInit()).toThrow(
+      'STELLAR_WEBHOOK_SECRET must be set',
+    );
+  });
+
+  it('should successfully validate signature and add to queue', async () => {
+    const body: StellarWebhookDto = makeBody();
+    const expectedSignature = signBody(body);
 
     const result = await controller.handleWebhook(expectedSignature, body);
 
@@ -84,13 +114,16 @@ describe('StellarWebhookController', () => {
       body,
       expect.any(Object),
     );
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'stellar-webhook:event:evt-123',
+      expect.any(String),
+      24 * 60 * 60 * 1000,
+    );
     expect(logger.info).toHaveBeenCalled();
   });
 
   it('should throw UnauthorizedException if signature header is missing', async () => {
-    const body: StellarWebhookDto = {
-      transactionHash: 'tx-hash-123',
-    };
+    const body: StellarWebhookDto = makeBody();
 
     await expect(
       controller.handleWebhook(undefined as any, body),
@@ -99,13 +132,37 @@ describe('StellarWebhookController', () => {
   });
 
   it('should throw UnauthorizedException if signature is invalid', async () => {
-    const body: StellarWebhookDto = {
-      transactionHash: 'tx-hash-123',
-    };
+    const body: StellarWebhookDto = makeBody();
 
     await expect(controller.handleWebhook('invalid-sig', body)).rejects.toThrow(
       UnauthorizedException,
     );
     expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('should reject replayed webhook with an old valid signature', async () => {
+    const body: StellarWebhookDto = makeBody({
+      timestamp: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
+    });
+    const expectedSignature = signBody(body);
+
+    await expect(
+      controller.handleWebhook(expectedSignature, body),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('should reject duplicate webhook event IDs with a valid signature', async () => {
+    const body: StellarWebhookDto = makeBody();
+    const expectedSignature = signBody(body);
+
+    await expect(
+      controller.handleWebhook(expectedSignature, body),
+    ).resolves.toEqual({ received: true });
+    await expect(
+      controller.handleWebhook(expectedSignature, body),
+    ).rejects.toThrow(ConflictException);
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/webhooks/stellar-webhook.controller.ts
+++ b/src/webhooks/stellar-webhook.controller.ts
@@ -4,17 +4,30 @@ import {
   Body,
   Headers,
   UnauthorizedException,
+  ConflictException,
   HttpCode,
   HttpStatus,
+  Inject,
+  OnModuleInit,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 import * as crypto from 'crypto';
 import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 import { LoggerService } from '../common/logger/logger.service';
 
 export class StellarWebhookDto {
+  @IsString()
+  @IsNotEmpty()
+  eventId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  timestamp: string;
+
   @IsString()
   @IsNotEmpty()
   transactionHash: string;
@@ -28,13 +41,21 @@ export class StellarWebhookDto {
 }
 
 @Controller('webhooks/stellar')
-export class StellarWebhookController {
+export class StellarWebhookController implements OnModuleInit {
+  private static readonly SIGNATURE_TOLERANCE_MS = 5 * 60 * 1000;
+  private static readonly EVENT_ID_TTL_MS = 24 * 60 * 60 * 1000;
+
   constructor(
     @InjectQueue('stellar-webhook')
     private readonly stellarWebhookQueue: Queue,
     private readonly configService: ConfigService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
     private readonly logger: LoggerService,
   ) {}
+
+  onModuleInit() {
+    this.getWebhookSecret();
+  }
 
   @Post()
   @HttpCode(HttpStatus.OK)
@@ -43,6 +64,7 @@ export class StellarWebhookController {
     @Body() body: StellarWebhookDto,
   ) {
     this.logger.info('Received Stellar webhook request', {
+      eventId: body.eventId,
       transactionHash: body.transactionHash,
     });
 
@@ -51,11 +73,11 @@ export class StellarWebhookController {
       throw new UnauthorizedException('Missing signature header');
     }
 
-    const secret =
-      this.configService.get<string>('STELLAR_WEBHOOK_SECRET') ||
-      'stellar-webhook-secret-key-change-in-production';
+    this.validateTimestamp(body.timestamp);
 
-    // Compute HMAC signature on the stringified body
+    const secret = this.getWebhookSecret();
+
+    // Compute HMAC signature on the stringified body, including eventId and timestamp.
     const payload = JSON.stringify(body);
     const expectedSignature = crypto
       .createHmac('sha256', secret)
@@ -74,6 +96,8 @@ export class StellarWebhookController {
       throw new UnauthorizedException('Invalid signature');
     }
 
+    await this.rejectDuplicateEvent(body.eventId);
+
     // Add webhook to Bull queue for asynchronous processing
     await this.stellarWebhookQueue.add('process-payment', body, {
       attempts: 3,
@@ -86,9 +110,56 @@ export class StellarWebhookController {
     });
 
     this.logger.info('Stellar webhook accepted and queued for processing', {
+      eventId: body.eventId,
       transactionHash: body.transactionHash,
     });
 
     return { received: true };
+  }
+
+  private getWebhookSecret(): string {
+    const secret = this.configService.get<string>('STELLAR_WEBHOOK_SECRET');
+
+    if (!secret || secret.trim() === '') {
+      throw new Error('STELLAR_WEBHOOK_SECRET must be set');
+    }
+
+    return secret;
+  }
+
+  private validateTimestamp(timestamp: string): void {
+    const timestampMs = Date.parse(timestamp);
+
+    if (Number.isNaN(timestampMs)) {
+      this.logger.warn('Stellar webhook rejected: Invalid timestamp');
+      throw new UnauthorizedException('Invalid timestamp');
+    }
+
+    const ageMs = Math.abs(Date.now() - timestampMs);
+
+    if (ageMs > StellarWebhookController.SIGNATURE_TOLERANCE_MS) {
+      this.logger.warn('Stellar webhook rejected: Stale timestamp', {
+        timestamp,
+      });
+      throw new UnauthorizedException('Stale timestamp');
+    }
+  }
+
+  private async rejectDuplicateEvent(eventId: string): Promise<void> {
+    const cacheKey = `stellar-webhook:event:${eventId}`;
+    const alreadyProcessed = await this.cache.get<string>(cacheKey);
+
+    if (alreadyProcessed) {
+      this.logger.warn('Stellar webhook rejected: Duplicate event', {
+        eventId,
+      });
+      throw new ConflictException('Duplicate event');
+    }
+
+    await this.cache.set(
+      cacheKey,
+      new Date().toISOString(),
+      StellarWebhookController.EVENT_ID_TTL_MS,
+    );
   }
 }

--- a/src/webhooks/stellar-webhook.processor.ts
+++ b/src/webhooks/stellar-webhook.processor.ts
@@ -26,9 +26,10 @@ export class StellarWebhookProcessor {
   @OnEvent(EventNames.PAYMENT_CONFIRMED)
   @Process('process-payment')
   async handleProcessPayment(job: Job<any>) {
-    const { transactionHash } = job.data;
+    const { eventId, transactionHash } = job.data;
     this.logger.info('Started processing Stellar payment event', {
       jobId: job.id,
+      eventId,
       transactionHash,
     });
 
@@ -140,6 +141,7 @@ export class StellarWebhookProcessor {
 
       this.logger.info(
         `Successfully processed Stellar payment event for transactionHash: ${transactionHash}`,
+        { eventId },
       );
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
## Summary

This PR strengthens the Stellar webhook security flow by preventing replay attacks and duplicate event processing. It introduces signed `eventId` and `timestamp` validation, removes the insecure fallback webhook secret, enforces idempotency using the application cache, and expands test coverage for the new security behavior.

**Closes:** #<issue-number>
closes #469 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / Maintenance

## Checklist

- [x] Tests added/updated
- [x] `npm run pr:check` passes locally
- [ ] Migration notes included (if applicable)
- [ ] Docs updated (if applicable)

## How to test

1. Run `npm run lint` and verify it completes successfully.
2. Run `npm run typecheck` and confirm there are no type errors.
3. Run:
   ```bash
   npm test -- stellar-webhook.controller.spec.ts stellar-webhook.processor.spec.ts --runInBand
   ```
   and verify all webhook tests pass.
4. Run:
   ```bash
   npm run pr:check
   ```
   and confirm the full PR checks (lint, typecheck, and tests) complete successfully.
5. Verify that:
   - Signed webhook requests containing valid `eventId` and `timestamp` are accepted.
   - Requests older than the configured tolerance window are rejected.
   - Duplicate `eventId` values are rejected.
   - Application startup fails when `STELLAR_WEBHOOK_SECRET` is not configured.