### PR TITLE
[security] Add auth guards to escrow endpoints (unauthenticated fund release)

### DIFF
--- a/src/escrow/dto/create-escrow.dto.ts
+++ b/src/escrow/dto/create-escrow.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsNumber, IsPositive, IsUUID } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsUUID,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateEscrowDto {
@@ -11,12 +17,13 @@ export class CreateEscrowDto {
   amount: number;
 
   @ApiProperty({
-    description: 'UUID of the buyer initiating the escrow',
+    description:
+      'Deprecated: ignored. Buyer is derived from the authenticated user.',
     example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
   })
   @IsUUID()
-  @IsNotEmpty()
-  buyerId: string;
+  @IsOptional()
+  buyerId?: string;
 
   @ApiProperty({
     description: 'UUID of the seller who will receive the funds on release',

--- a/src/escrow/escrow.controller.ts
+++ b/src/escrow/escrow.controller.ts
@@ -7,15 +7,19 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { EscrowService } from './escrow.service';
 import { CreateEscrowDto } from './dto/create-escrow.dto';
 import { Escrow } from '../entities/escrow.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('Escrow')
 @Controller('escrow')
+@UseGuards(JwtAuthGuard)
 export class EscrowController {
   constructor(private readonly escrowService: EscrowService) {}
 
@@ -31,8 +35,14 @@ export class EscrowController {
   @ApiResponse({ status: 201, description: 'Escrow created and funded.' })
   @ApiResponse({ status: 400, description: 'Validation error.' })
   @ApiResponse({ status: 500, description: 'Stellar network error.' })
-  async create(@Body() createEscrowDto: CreateEscrowDto): Promise<Escrow> {
-    return this.escrowService.createEscrow(createEscrowDto);
+  async create(
+    @Req() req: { user: { id: string } },
+    @Body() createEscrowDto: CreateEscrowDto,
+  ): Promise<Escrow> {
+    return this.escrowService.createEscrow({
+      ...createEscrowDto,
+      buyerId: req.user.id,
+    });
   }
 
   @Post(':id/release')
@@ -52,8 +62,11 @@ export class EscrowController {
   })
   @ApiResponse({ status: 404, description: 'Escrow not found.' })
   @ApiResponse({ status: 500, description: 'Stellar network error.' })
-  async release(@Param('id', ParseUUIDPipe) id: string): Promise<Escrow> {
-    return this.escrowService.releaseEscrow(id);
+  async release(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: { user: { id: string; role?: string } },
+  ): Promise<Escrow> {
+    return this.escrowService.releaseEscrow(id, req.user);
   }
 
   @Get(':id')

--- a/src/escrow/escrow.service.spec.ts
+++ b/src/escrow/escrow.service.spec.ts
@@ -2,16 +2,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { Repository } from 'typeorm';
 import * as StellarSdk from '@stellar/stellar-sdk';
 import axios from 'axios';
 
 import { EscrowService } from './escrow.service';
+import { EscrowController } from './escrow.controller';
 import { Escrow, EscrowStatus } from '../entities/escrow.entity';
 import { LoggerService } from '../common/logger/logger.service';
 import { EncryptionService } from '../common/services/encryption.service';
 import { CreateEscrowDto } from './dto/create-escrow.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -64,6 +71,40 @@ function buildMockEscrow(overrides: Partial<Escrow> = {}): Escrow {
 // ---------------------------------------------------------------------------
 // Test Suite
 // ---------------------------------------------------------------------------
+
+const actingBuyer = { id: 'buyer-uuid-5678' };
+const actingSeller = { id: 'seller-uuid-9012' };
+const actingAdmin = { id: 'admin-uuid', role: 'admin' };
+
+describe('EscrowController', () => {
+  it('rejects unauthenticated escrow requests by requiring JwtAuthGuard', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, EscrowController) as
+      | unknown[]
+      | undefined;
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('overrides any client-supplied buyerId with req.user.id', async () => {
+    const escrowService = {
+      createEscrow: jest.fn().mockResolvedValue(buildMockEscrow()),
+    };
+    const controller = new EscrowController(
+      escrowService as unknown as EscrowService,
+    );
+
+    await controller.create(
+      { user: { id: 'authenticated-buyer-id' } },
+      { amount: 100, buyerId: 'attacker-buyer-id', sellerId: 'seller-id' },
+    );
+
+    expect(escrowService.createEscrow).toHaveBeenCalledWith({
+      amount: 100,
+      buyerId: 'authenticated-buyer-id',
+      sellerId: 'seller-id',
+    });
+  });
+});
 
 describe('EscrowService', () => {
   let service: EscrowService;
@@ -272,12 +313,66 @@ describe('EscrowService', () => {
         { stellarWalletAddress: MOCK_SELLER_KEYPAIR.publicKey() },
       ]);
 
-      const result = await service.releaseEscrow('escrow-uuid-1234');
+      const result = await service.releaseEscrow(
+        'escrow-uuid-1234',
+        actingBuyer,
+      );
 
       expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
       expect(result.status).toBe(EscrowStatus.RELEASED);
       expect(result.transactionHash).toBe('release-tx-hash-xyz');
       expect(result.released).toBe(true);
+    });
+
+    it('allows the seller party to release the escrow', async () => {
+      const fundedEscrow = buildMockEscrow();
+      escrowRepo.findOne.mockResolvedValue(fundedEscrow);
+      escrowRepo.save.mockResolvedValue({
+        ...fundedEscrow,
+        status: EscrowStatus.RELEASED,
+      });
+      mockLoadAccount.mockResolvedValue(
+        new StellarSdk.Account(MOCK_ESCROW_KEYPAIR.publicKey(), '100'),
+      );
+      mockSubmitTransaction.mockResolvedValue({ hash: 'release-tx-hash-xyz' });
+      mockManager.query.mockResolvedValue([
+        { stellarWalletAddress: MOCK_SELLER_KEYPAIR.publicKey() },
+      ]);
+
+      await service.releaseEscrow('escrow-uuid-1234', actingSeller);
+
+      expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows an admin to release the escrow even when not a party', async () => {
+      const fundedEscrow = buildMockEscrow();
+      escrowRepo.findOne.mockResolvedValue(fundedEscrow);
+      escrowRepo.save.mockResolvedValue({
+        ...fundedEscrow,
+        status: EscrowStatus.RELEASED,
+      });
+      mockLoadAccount.mockResolvedValue(
+        new StellarSdk.Account(MOCK_ESCROW_KEYPAIR.publicKey(), '100'),
+      );
+      mockSubmitTransaction.mockResolvedValue({ hash: 'release-tx-hash-xyz' });
+      mockManager.query.mockResolvedValue([
+        { stellarWalletAddress: MOCK_SELLER_KEYPAIR.publicKey() },
+      ]);
+
+      await service.releaseEscrow('escrow-uuid-1234', actingAdmin);
+
+      expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects release attempts from users who are neither parties nor admins', async () => {
+      const fundedEscrow = buildMockEscrow();
+      escrowRepo.findOne.mockResolvedValue(fundedEscrow);
+
+      await expect(
+        service.releaseEscrow('escrow-uuid-1234', { id: 'stranger-uuid' }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockLoadAccount).not.toHaveBeenCalled();
+      expect(mockSubmitTransaction).not.toHaveBeenCalled();
     });
 
     it('decrypts the stored secret and signs the release transaction with the escrow keypair', async () => {
@@ -296,7 +391,7 @@ describe('EscrowService', () => {
         { stellarWalletAddress: MOCK_SELLER_KEYPAIR.publicKey() },
       ]);
 
-      await service.releaseEscrow('escrow-uuid-1234');
+      await service.releaseEscrow('escrow-uuid-1234', actingBuyer);
 
       const submittedTx = mockSubmitTransaction.mock
         .calls[0][0] as StellarSdk.Transaction;
@@ -326,7 +421,7 @@ describe('EscrowService', () => {
         { stellarWalletAddress: MOCK_SELLER_KEYPAIR.publicKey() },
       ]);
 
-      await service.releaseEscrow('escrow-uuid-1234');
+      await service.releaseEscrow('escrow-uuid-1234', actingBuyer);
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('decrypted for transaction signing'),
@@ -353,18 +448,18 @@ describe('EscrowService', () => {
         getOne: jest.fn().mockResolvedValue({ escrowSecretKey: null }),
       });
 
-      await expect(service.releaseEscrow('escrow-uuid-1234')).rejects.toThrow(
-        'missing keypair data',
-      );
+      await expect(
+        service.releaseEscrow('escrow-uuid-1234', actingBuyer),
+      ).rejects.toThrow('missing keypair data');
     });
 
     it('should throw BadRequestException when escrow is not FUNDED', async () => {
       const releasedEscrow = buildMockEscrow({ status: EscrowStatus.RELEASED });
       escrowRepo.findOne.mockResolvedValue(releasedEscrow);
 
-      await expect(service.releaseEscrow('escrow-uuid-1234')).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.releaseEscrow('escrow-uuid-1234', actingBuyer),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should throw InternalServerErrorException when escrow has no keypair', async () => {
@@ -374,9 +469,9 @@ describe('EscrowService', () => {
       });
       escrowRepo.findOne.mockResolvedValue(brokenEscrow);
 
-      await expect(service.releaseEscrow('escrow-uuid-1234')).rejects.toThrow(
-        'missing keypair data',
-      );
+      await expect(
+        service.releaseEscrow('escrow-uuid-1234', actingBuyer),
+      ).rejects.toThrow('missing keypair data');
     });
 
     it('should throw InternalServerErrorException on Stellar submission error', async () => {
@@ -391,9 +486,9 @@ describe('EscrowService', () => {
       ]);
       mockSubmitTransaction.mockRejectedValue(new Error('Horizon error'));
 
-      await expect(service.releaseEscrow('escrow-uuid-1234')).rejects.toThrow(
-        'Stellar escrow release failed',
-      );
+      await expect(
+        service.releaseEscrow('escrow-uuid-1234', actingBuyer),
+      ).rejects.toThrow('Stellar escrow release failed');
     });
   });
 

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
@@ -14,6 +15,11 @@ import { Escrow, EscrowStatus } from '../entities/escrow.entity';
 import { LoggerService } from '../common/logger/logger.service';
 import { EncryptionService } from '../common/services/encryption.service';
 import { CreateEscrowDto } from './dto/create-escrow.dto';
+
+export interface EscrowActor {
+  id: string;
+  role?: string;
+}
 
 @Injectable()
 export class EscrowService {
@@ -59,8 +65,14 @@ export class EscrowService {
    *       the buyer to sign a payment from their own Stellar account instead.
    */
   async createEscrow(dto: CreateEscrowDto): Promise<Escrow> {
+    if (!dto.buyerId) {
+      throw new BadRequestException('Authenticated buyer is required');
+    }
+
+    const buyerId = dto.buyerId;
+
     this.logger.info('Creating escrow', {
-      buyerId: dto.buyerId,
+      buyerId,
       sellerId: dto.sellerId,
       amount: dto.amount,
     });
@@ -76,7 +88,7 @@ export class EscrowService {
     // envelope-encrypted at rest; it is only ever decrypted in-memory, and
     // only at the point of signing a release transaction.
     const escrow = this.escrowRepository.create({
-      buyerId: dto.buyerId,
+      buyerId,
       sellerId: dto.sellerId,
       amount: dto.amount,
       status: EscrowStatus.PENDING,
@@ -131,10 +143,14 @@ export class EscrowService {
    * purposes, if the seller has no wallet address, a new random keypair is
    * generated and Friendbot-funded as a stand-in destination.
    */
-  async releaseEscrow(escrowId: string): Promise<Escrow> {
+  async releaseEscrow(
+    escrowId: string,
+    actingUser: EscrowActor,
+  ): Promise<Escrow> {
     this.logger.info('Releasing escrow', { escrowId });
 
     const escrow = await this.findOne(escrowId);
+    this.assertReleaseAccess(escrow, actingUser);
 
     if (escrow.status !== EscrowStatus.FUNDED) {
       throw new BadRequestException(
@@ -215,6 +231,18 @@ export class EscrowService {
       // so the operator can retry or investigate.
       throw new InternalServerErrorException(
         'Stellar escrow release failed. See server logs for details.',
+      );
+    }
+  }
+
+  private assertReleaseAccess(escrow: Escrow, actingUser: EscrowActor): void {
+    const isParty =
+      actingUser.id === escrow.buyerId || actingUser.id === escrow.sellerId;
+    const isAdmin = actingUser.role === 'admin';
+
+    if (!isParty && !isAdmin) {
+      throw new ForbiddenException(
+        'You are not allowed to release this escrow',
       );
     }
   }


### PR DESCRIPTION
## Summary

Strengthens escrow security by requiring authentication for all escrow endpoints and enforcing authorization for escrow release operations. This PR derives the buyer identity from the authenticated user instead of client input, preventing buyer spoofing and ensuring only authorized participants (buyer, seller, or an administrator) can release escrowed funds.

**Closes:** #<issue-number>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore / Maintenance

## Checklist

- [x] Tests added/updated
- [x] `npm run pr:check` passes locally
- [ ] Migration notes included (if applicable)
- [ ] Docs updated (if applicable)

## How to test

1. Run the escrow unit tests:
   ```bash
   npm test -- escrow.service.spec.ts --runInBand
   ```
   Verify all **18 tests pass**.

2. Run the full project validation:
   ```bash
   npm run pr:check
   ```
   Confirm the checks complete successfully with:
   - **22 test suites passed**
   - **1 test suite skipped**
   - **236 tests passed**
   - **7 tests skipped**

3. Verify the application behavior:
   - All escrow endpoints require authentication via `JwtAuthGuard`.
   - Creating an escrow always uses the authenticated user's ID as the buyer, regardless of any client-provided value.
   - Escrow release succeeds only when performed by the buyer, seller, or an administrator.
   - Unauthorized users attempting to release an escrow receive an authorization error.

4. Confirm the following commands complete successfully:
   ```bash
   npm run lint
   npm run typecheck
   npm run build
   ```
   
   closes #465 