### PR TITLE
fix: register ThrottlerGuard as global APP_GUARD and add 429 smoke test

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,8 @@
 import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { BullModule } from '@nestjs/bull';
 import { CacheModule } from '@nestjs/cache-manager';
 import { redisStore } from 'cache-manager-redis-yet';
@@ -34,7 +35,12 @@ import { ReviewModule } from './review/review.module';
 
     ThrottlerModule.forRootAsync({
       useFactory: () => ({
-        throttlers: [{ ttl: 60_000, limit: 100 }],
+        throttlers: [
+          {
+            ttl: parseInt(process.env.THROTTLE_TTL || '60000', 10),
+            limit: parseInt(process.env.THROTTLE_LIMIT || '100', 10),
+          },
+        ],
       }),
     }),
 
@@ -92,7 +98,15 @@ import { ReviewModule } from './review/review.module';
     EscrowModule,
   ],
   controllers: [AppController],
-  providers: [AppService, AdminGuard, RolesGuard],
+  providers: [
+    AppService,
+    AdminGuard,
+    RolesGuard,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
   exports: [AdminGuard, RolesGuard, LoggerModule],
 })
 export class AppModule implements NestModule {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -61,12 +61,8 @@ describe('Application health (e2e)', () => {
   it('GET /health/live — returns 429 after exceeding rate limit', async () => {
     const limit = 5;
     for (let i = 0; i < limit; i++) {
-      await request(ctx.app.getHttpServer())
-        .get('/health/live')
-        .expect(200);
+      await request(ctx.app.getHttpServer()).get('/health/live').expect(200);
     }
-    await request(ctx.app.getHttpServer())
-      .get('/health/live')
-      .expect(429);
+    await request(ctx.app.getHttpServer()).get('/health/live').expect(429);
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -20,10 +20,12 @@ describe('Application health (e2e)', () => {
   let ctx: E2EApp;
 
   beforeAll(async () => {
+    process.env.THROTTLE_LIMIT = '5';
     ctx = await createE2EApp();
   }, 120_000);
 
   afterAll(async () => {
+    delete process.env.THROTTLE_LIMIT;
     await teardownE2EApp(ctx);
   });
 
@@ -54,5 +56,17 @@ describe('Application health (e2e)', () => {
     await request(ctx.app.getHttpServer())
       .get('/this-route-does-not-exist')
       .expect(404);
+  });
+
+  it('GET /health/live — returns 429 after exceeding rate limit', async () => {
+    const limit = 5;
+    for (let i = 0; i < limit; i++) {
+      await request(ctx.app.getHttpServer())
+        .get('/health/live')
+        .expect(200);
+    }
+    await request(ctx.app.getHttpServer())
+      .get('/health/live')
+      .expect(429);
   });
 });


### PR DESCRIPTION


---

## Summary
`ThrottlerModule` was configured in `app.module.ts` at 100 req/60s but `ThrottlerGuard` was never registered as a global `APP_GUARD` and no controller applied it directly. Every `@Throttle()` override on auth endpoints was silently a no-op — no route in the application was actually rate-limited. This PR wires the guard globally so the existing configuration and per-route overrides take effect immediately.

Closes #471

---

## What changed

`src/app.module.ts`
- Registered `ThrottlerGuard` as a global `APP_GUARD` in the providers array — rate limiting is now active on every route by default with no per-controller changes required
- Existing `@Throttle()` overrides on auth endpoints are unchanged and now take effect correctly since the underlying guard is active

`test/app.e2e-spec.ts`
- Added a smoke test that fires requests against a rate-limited route in excess of its configured limit and asserts a `429 Too Many Requests` response is returned once the threshold is crossed
- Asserts the response before the limit is reached returns the expected success status — confirming the guard is not over-blocking

---

## How to verify
- Send more than 100 requests within 60 seconds to any undecorated route and assert `429` is returned after the threshold
- Send requests to an auth endpoint with a `@Throttle()` override and assert its specific limit is enforced rather than the global default
- Send requests below the limit threshold and assert normal responses are returned without interference
- Run `test/app.e2e-spec.ts` and confirm the new smoke test passes
- Run the full test suite and confirm no regressions

---

## Checklist
- [ ] `ThrottlerGuard` registered as global `APP_GUARD` in `src/app.module.ts`
- [ ] Existing `@Throttle()` overrides on auth endpoints now take effect
- [ ] Smoke test added in `test/app.e2e-spec.ts` asserting `429` after limit is exceeded
- [ ] Requests below the limit return expected success responses
- [ ] Full test suite passes with no regressions
- [ ] Closes #471